### PR TITLE
CI実行時node_modulesをキャッシュする

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
           node-version: 18.6.0
           cache: 'yarn'
           cache-dependency-path: yarn.lock
-      - uses: actions/cache
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,11 @@ jobs:
           node-version: 18.6.0
           cache: 'yarn'
           cache-dependency-path: yarn.lock
+      - uses: actions/cache
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn lint

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 const config = {
   verbose: true,
+  collectCoverage: true,
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 const Index: NextPage<Props> = ({ characters }) => (
   <Container>
     <Box sx={{ p: 1 }}>
-      <Typography variant="h5">互換キャラサーチ</Typography>
+      <Typography variant="h5">コンパチサーチ</Typography>
     </Box>
     <CharactersSearcher characters={characters} />
   </Container>


### PR DESCRIPTION
Resolve #26 
- `actions/cache@v3` を使って `node_modules` をキャッシュしインストールにかかる時間を減らす
- おまけ
    - テスト実行時にカバレッジを取得する
    - ページのタイトルをリポジトリ名変更に合わせる