### PR TITLE
デフォルトで全キャラクターを表示する

### DIFF
--- a/components/organisms/CharactersSearcher.tsx
+++ b/components/organisms/CharactersSearcher.tsx
@@ -62,7 +62,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
           <SearchCondition {...searchCondition} />
         </Box>
       ) : null}
-      <Grid container spacing={2} sx={{ mt: 1, pb: 2 }}>
+      <Grid container spacing={2} sx={{ mt: 1 }}>
         {searchResults.map(({ name, tags }) => (
           <Grid item key={name} xs={12} sm={6} md={4}>
             <CharacterCard name={name} tags={tags} onClickTag={onClickTag} />

--- a/components/organisms/CharactersSearcher.tsx
+++ b/components/organisms/CharactersSearcher.tsx
@@ -27,7 +27,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   const [searchText, setSearchText] = React.useState('');
   const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
   const [searchResults, setSearchResults] = React.useState<TaggedCharacter[]>(
-    []
+    characters
   );
   const [searchCondition, setSearchCondition] =
     React.useState<SearchCondition | null>(null);
@@ -63,7 +63,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
           <SearchCondition {...searchCondition} />
         </Box>
       ) : null}
-      <Grid container spacing={2} sx={{ mt: 1 }}>
+      <Grid container spacing={2} sx={{ mt: 1, pb: 2 }}>
         {searchResults.map(({ name, tags }) => (
           <Grid item key={name} xs={12} sm={6} md={4}>
             <CharacterCard name={name} tags={tags} onClickTag={onClickTag} />

--- a/components/organisms/CharactersSearcher.tsx
+++ b/components/organisms/CharactersSearcher.tsx
@@ -26,9 +26,8 @@ interface SearchCondition {
 export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   const [searchText, setSearchText] = React.useState('');
   const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
-  const [searchResults, setSearchResults] = React.useState<TaggedCharacter[]>(
-    characters
-  );
+  const [searchResults, setSearchResults] =
+    React.useState<TaggedCharacter[]>(characters);
   const [searchCondition, setSearchCondition] =
     React.useState<SearchCondition | null>(null);
   const search = (text: string, target: SearchTarget) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,11 +13,11 @@ interface Props {
 }
 
 const Index: NextPage<Props> = ({ characters }) => (
-  <Container>
-    <Box sx={{ p: 1 }}>
-      <Typography variant="h5">コンパチサーチ</Typography>
+  <Container sx={{ py: 2 }}>
+    <Typography variant="h5">コンパチサーチ</Typography>
+    <Box sx={{ mt: 2 }}>
+      <CharactersSearcher characters={characters} />
     </Box>
-    <CharactersSearcher characters={characters} />
   </Container>
 );
 

--- a/stories/atoms/TagBadge.stories.tsx
+++ b/stories/atoms/TagBadge.stories.tsx
@@ -8,9 +8,6 @@ const componentMeta: ComponentMeta<typeof TagBadge> = {
   component: TagBadge,
   argTypes: {
     children: { control: 'text' },
-    onClick: {
-      action: 'clicked',
-    },
   },
 };
 export default componentMeta;

--- a/stories/molecules/CharacterCard.stories.tsx
+++ b/stories/molecules/CharacterCard.stories.tsx
@@ -9,7 +9,6 @@ const componentMeta: ComponentMeta<typeof CharacterCard> = {
   argTypes: {
     name: { control: 'text' },
     tags: { control: 'object' },
-    onClickTag: { action: 'clickedTag' },
   },
 };
 export default componentMeta;

--- a/stories/molecules/SearchForm.stories.tsx
+++ b/stories/molecules/SearchForm.stories.tsx
@@ -9,7 +9,6 @@ const componentMeta: ComponentMeta<typeof SearchForm> = {
   component: SearchForm,
   argTypes: {
     text: { control: 'text' },
-    onChangeText: { action: 'changedText' },
     target: {
       options: [SearchTarget.TAG, SearchTarget.NAME],
       control: {
@@ -19,10 +18,6 @@ const componentMeta: ComponentMeta<typeof SearchForm> = {
           [SearchTarget.NAME]: '名前',
         },
       },
-    },
-    onChangeTarget: { action: 'changedTarget' },
-    onSearch: {
-      action: 'searched',
     },
   },
 };

--- a/stories/molecules/SearchTargetSelect.stories.tsx
+++ b/stories/molecules/SearchTargetSelect.stories.tsx
@@ -20,9 +20,6 @@ const componentMeta: ComponentMeta<typeof SearchTargetSelect> = {
         },
       },
     },
-    onChange: {
-      action: 'changed',
-    },
   },
 };
 export default componentMeta;


### PR DESCRIPTION
- 検索対象のキャラクターをすべて表示して最初の検索をしやすくする
- おまけ: キャラ表示に下部余白を足す
    - キャラ数が多いと下部余白が足りないため
- おまけ: タイトルと検索フォームの余白調整
- おまけ: storybookのactionsをデフォルトに任せる