### PR TITLE
入力フォームの補完ができるようにする

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ storybook-static/
 package.json
 next-env.d.ts
 README.md
+coverage/

--- a/components/molecules/SearchCondition.tsx
+++ b/components/molecules/SearchCondition.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import React from 'react';
-import { SearchTarget } from './SearchTargetSelect';
+import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
   target: SearchTarget;

--- a/components/molecules/SearchForm.tsx
+++ b/components/molecules/SearchForm.tsx
@@ -69,8 +69,8 @@ export const SearchForm: React.FC<Props> = ({
         filterSelectedOptions
         value={texts}
         onChange={onTextChange}
-        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-        /* @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする */
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする
         options={options}
         fullWidth
         renderInput={(params) => (

--- a/components/molecules/SearchForm.tsx
+++ b/components/molecules/SearchForm.tsx
@@ -69,6 +69,8 @@ export const SearchForm: React.FC<Props> = ({
         filterSelectedOptions
         value={texts}
         onChange={onTextChange}
+        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+        /* @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする */
         options={options}
         fullWidth
         renderInput={(params) => (

--- a/components/molecules/SearchForm.tsx
+++ b/components/molecules/SearchForm.tsx
@@ -1,21 +1,23 @@
-import React, { ChangeEventHandler, FormEventHandler } from 'react';
-import OutlinedInput from '@mui/material/OutlinedInput';
+import React, { FormEventHandler } from 'react';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
 import SearchIcon from '@mui/icons-material/Search';
 import { useTheme } from '@mui/material/styles';
-import { SearchTarget, SearchTargetSelect } from './SearchTargetSelect';
+import { SearchTargetSelect } from './SearchTargetSelect';
+import Autocomplete from '@mui/material/Autocomplete';
+import { TextField } from '@mui/material';
+import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
   /**
    * 検索文字列
    */
-  text: string;
+  texts: string[];
   /**
    * 検索文字列の変更ハンドラ
-   * @param text - 変更後の検索文字列
+   * @param texts - 変更後の検索文字列
    */
-  onChangeText: (text: string) => void;
+  onChangeTexts: (texts: string[]) => void;
   /**
    * 検索対象
    */
@@ -26,25 +28,29 @@ interface Props {
    */
   onChangeTarget: (target: SearchTarget) => void;
   /**
+   * 検索ワードの補完候補
+   */
+  options: string[];
+  /**
    * 検索イベントのハンドラー
    * @param text - 検索文字列
    */
-  onSearch: (text: string, target: SearchTarget) => void;
+  onSearch: (texts: string[], target: SearchTarget) => void;
 }
 
 export const SearchForm: React.FC<Props> = ({
-  text,
-  onChangeText,
+  texts,
+  onChangeTexts,
   target,
   onChangeTarget,
+  options,
   onSearch,
 }) => {
-  const onTextChange: ChangeEventHandler<HTMLInputElement> = (event) =>
-    onChangeText(event.target.value);
+  const onTextChange = (_, texts: string[]) => onChangeTexts(texts);
   const startSearch: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    if (text) {
-      onSearch(text, target);
+    if (texts.length > 0) {
+      onSearch(texts, target);
     }
   };
   const theme = useTheme();
@@ -57,19 +63,30 @@ export const SearchForm: React.FC<Props> = ({
       sx={{ display: 'flex', alignItems: 'center' }}
     >
       <SearchTargetSelect target={target} onChange={onChangeTarget} />
-      <OutlinedInput
-        type="search"
-        placeholder={placeholder}
-        value={text}
+      <Autocomplete
+        autoComplete
+        multiple
+        filterSelectedOptions
+        value={texts}
         onChange={onTextChange}
-        endAdornment={
-          <IconButton type="submit">
-            <SearchIcon fontSize="large" />
-          </IconButton>
-        }
+        options={options}
         fullWidth
-        sx={{ fontSize: theme.typography.h5, ml: 2 }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            type="search"
+            placeholder={placeholder}
+            inputProps={{
+              ...params.inputProps,
+              sx: { fontSize: theme.typography.h5 },
+            }}
+          />
+        )}
+        sx={{ ml: 2 }}
       />
+      <IconButton type="submit">
+        <SearchIcon fontSize="large" />
+      </IconButton>
     </Box>
   );
 };

--- a/components/molecules/SearchForm.tsx
+++ b/components/molecules/SearchForm.tsx
@@ -86,7 +86,7 @@ export const SearchForm: React.FC<Props> = ({
         )}
         sx={{ ml: 2 }}
       />
-      <IconButton type="submit">
+      <IconButton type="submit" sx={{ ml: 1 }}>
         <SearchIcon fontSize="large" />
       </IconButton>
     </Box>

--- a/components/molecules/SearchForm.tsx
+++ b/components/molecules/SearchForm.tsx
@@ -5,7 +5,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import { useTheme } from '@mui/material/styles';
 import { SearchTargetSelect } from './SearchTargetSelect';
 import Autocomplete from '@mui/material/Autocomplete';
-import { TextField } from '@mui/material';
+import { Chip, TextField } from '@mui/material';
 import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
@@ -84,6 +84,18 @@ export const SearchForm: React.FC<Props> = ({
             }}
           />
         )}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore valueの要求型が明らかにおかしいから一時的にignoreする
+        renderTags={(value: string[], getTagProps) =>
+          value.map((option: string, index: number) => (
+            <Chip
+              key={option}
+              label={option}
+              {...getTagProps({ index })}
+              sx={{ fontSize: theme.typography.h6 }}
+            />
+          ))
+        }
         sx={{ ml: 2 }}
       />
       <IconButton type="submit" sx={{ ml: 1 }}>

--- a/components/molecules/SearchTargetSelect.tsx
+++ b/components/molecules/SearchTargetSelect.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/material';
-
-export enum SearchTarget {
-  TAG,
-  NAME,
-}
+import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
   /**

--- a/components/organisms/CharactersSearcher.tsx
+++ b/components/organisms/CharactersSearcher.tsx
@@ -8,8 +8,9 @@ import {
 import { CharacterCard } from '../molecules/CharacterCard';
 import { SearchForm } from '../molecules/SearchForm';
 import Box from '@mui/material/Box';
-import { SearchTarget } from '../molecules/SearchTargetSelect';
 import { SearchCondition } from '../molecules/SearchCondition';
+import { generateAutoCompleteOptions } from '../../lib/autocomplete';
+import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
   /**
@@ -24,37 +25,41 @@ interface SearchCondition {
 }
 
 export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
-  const [searchText, setSearchText] = React.useState('');
+  const [searchTexts, setSearchTexts] = React.useState<string[]>([]);
   const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
   const [searchResults, setSearchResults] =
     React.useState<TaggedCharacter[]>(characters);
   const [searchCondition, setSearchCondition] =
     React.useState<SearchCondition | null>(null);
-  const search = (text: string, target: SearchTarget) => {
-    const words = text.split(/\s/);
+  const search = (texts: string[], target: SearchTarget) => {
     const searchResults =
       target === SearchTarget.TAG
-        ? filterCharactersByTags(characters, words)
-        : filterCharactersByNameWords(characters, words);
+        ? filterCharactersByTags(characters, texts)
+        : filterCharactersByNameWords(characters, texts);
     setSearchResults(searchResults);
     setSearchCondition({
       target,
-      text,
+      text: texts.join(' '),
     });
   };
   const onClickTag = (tag: string) => {
-    setSearchText(tag);
+    setSearchTexts([tag]);
     setSearchTarget(SearchTarget.TAG);
-    search(tag, SearchTarget.TAG);
+    search([tag], SearchTarget.TAG);
   };
+  const autoCompleteOptions = generateAutoCompleteOptions(
+    characters,
+    searchTarget
+  );
 
   return (
     <Box>
       <SearchForm
-        text={searchText}
-        onChangeText={setSearchText}
+        texts={searchTexts}
+        onChangeTexts={setSearchTexts}
         target={searchTarget}
         onChangeTarget={setSearchTarget}
+        options={autoCompleteOptions}
         onSearch={search}
       />
       {searchCondition ? (

--- a/lib/autocomplete.spec.ts
+++ b/lib/autocomplete.spec.ts
@@ -1,5 +1,5 @@
-import { SearchTarget } from '../components/molecules/SearchTargetSelect';
 import { generateAutoCompleteOptions } from './autocomplete';
+import { SearchTarget } from './search-target';
 import { TaggedCharacter } from './tagged-character';
 
 describe('generateAutoCompleteOptions', () => {

--- a/lib/autocomplete.spec.ts
+++ b/lib/autocomplete.spec.ts
@@ -1,0 +1,36 @@
+import { SearchTarget } from '../components/molecules/SearchTargetSelect';
+import { generateAutoCompleteOptions } from './autocomplete';
+import { TaggedCharacter } from './tagged-character';
+
+describe('generateAutoCompleteOptions', () => {
+  const characters: TaggedCharacter[] = [
+    {
+      name: 'Alpha',
+      tags: ['x-ray', 'yankee'],
+    },
+    {
+      name: 'Beta',
+      tags: ['x-ray', 'zulu'],
+    },
+    {
+      name: 'Gamma',
+      tags: ['yankee'],
+    },
+  ];
+
+  describe('検索対象がタグの場合', () => {
+    it('タグの一覧を重複なく返す', () => {
+      expect(generateAutoCompleteOptions(characters, SearchTarget.TAG)).toEqual(
+        ['x-ray', 'yankee', 'zulu']
+      );
+    });
+  });
+
+  describe('検索対象がタグの場合', () => {
+    it('名前の一覧を返す', () => {
+      expect(
+        generateAutoCompleteOptions(characters, SearchTarget.NAME)
+      ).toEqual(['Alpha', 'Beta', 'Gamma']);
+    });
+  });
+});

--- a/lib/autocomplete.ts
+++ b/lib/autocomplete.ts
@@ -1,0 +1,14 @@
+import { SearchTarget } from '../components/molecules/SearchTargetSelect';
+import { TaggedCharacter } from './tagged-character';
+
+export const generateAutoCompleteOptions = (
+  characters: TaggedCharacter[],
+  target: SearchTarget
+): string[] => {
+  switch (target) {
+    case SearchTarget.TAG:
+      return Array.from(new Set(characters.flatMap(({ tags }) => tags)));
+    case SearchTarget.NAME:
+      return characters.map(({ name }) => name);
+  }
+};

--- a/lib/autocomplete.ts
+++ b/lib/autocomplete.ts
@@ -1,5 +1,5 @@
-import { SearchTarget } from '../components/molecules/SearchTargetSelect';
 import { TaggedCharacter } from './tagged-character';
+import { SearchTarget } from './search-target';
 
 export const generateAutoCompleteOptions = (
   characters: TaggedCharacter[],

--- a/lib/search-target.ts
+++ b/lib/search-target.ts
@@ -1,0 +1,4 @@
+export enum SearchTarget {
+  TAG,
+  NAME,
+}

--- a/stories/molecules/SearchCondition.stories.tsx
+++ b/stories/molecules/SearchCondition.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { SearchCondition } from '../../components/molecules/SearchCondition';
-import { SearchTarget } from '../../components/molecules/SearchTargetSelect';
+import { SearchTarget } from '../../lib/search-target';
 
 const componentMeta: ComponentMeta<typeof SearchCondition> = {
   title: 'Molecules/SearchCondition',

--- a/stories/molecules/SearchForm.stories.tsx
+++ b/stories/molecules/SearchForm.stories.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { SearchForm } from '../../components/molecules/SearchForm';
-import { SearchTarget } from '../../components/molecules/SearchTargetSelect';
+import { SearchTarget } from '../../lib/search-target';
 
 const componentMeta: ComponentMeta<typeof SearchForm> = {
   title: 'Molecules/SearchForm',
   component: SearchForm,
   argTypes: {
-    text: { control: 'text' },
+    texts: { control: 'object' },
     target: {
       options: [SearchTarget.TAG, SearchTarget.NAME],
       control: {
@@ -19,6 +19,7 @@ const componentMeta: ComponentMeta<typeof SearchForm> = {
         },
       },
     },
+    options: { control: 'object' },
   },
 };
 export default componentMeta;
@@ -29,6 +30,7 @@ const Template: ComponentStory<typeof SearchForm> = (args) => (
 
 export const Search = Template.bind({});
 Search.args = {
-  text: '',
+  texts: [],
   target: SearchTarget.TAG,
+  options: ['あいうえお', 'かきくけこ'],
 };

--- a/stories/molecules/SearchTargetSelect.stories.tsx
+++ b/stories/molecules/SearchTargetSelect.stories.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import {
-  SearchTarget,
-  SearchTargetSelect,
-} from '../../components/molecules/SearchTargetSelect';
+import { SearchTargetSelect } from '../../components/molecules/SearchTargetSelect';
+import { SearchTarget } from '../../lib/search-target';
 
 const componentMeta: ComponentMeta<typeof SearchTargetSelect> = {
   title: 'Molecules/SearchTargetSelect',


### PR DESCRIPTION
Resolve #9 

- キャラデータから補完用データ生成関数を実装
- 入力フォームに補完機能追加
    - おまけ: 複数タグの管理が楽になった
- おまけ: `SearchTarget` の宣言をlibに移した
- おまけ: coverageをprettierに無視させた

画面スクショ
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/7444623/184439093-78f91fba-175d-47dc-8875-314bbc64968b.png">