### PR TITLE
一部キャラをデフォルトで表示しない

### DIFF
--- a/sample/characters-data/sample.json
+++ b/sample/characters-data/sample.json
@@ -1,66 +1,162 @@
 [
   {
     "name": "0",
-    "tags": []
+    "tags": [],
+    "showDefault": true
+  },
+  {
+    "name": "隠し0",
+    "tags": [],
+    "showDefault": false
   },
   {
     "name": "イチ",
-    "tags": ["Usa"]
+    "tags": ["Usa"],
+    "showDefault": true
+  },
+  {
+    "name": "隠しイチ",
+    "tags": ["Usa"],
+    "showDefault": false
   },
   {
     "name": "に",
-    "tags": ["コザ"]
+    "tags": ["コザ"],
+    "showDefault": true
+  },
+  {
+    "name": "隠しに",
+    "tags": ["コザ"],
+    "showDefault": false
   },
   {
     "name": "三",
-    "tags": ["さいたま"]
+    "tags": ["さいたま"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し三",
+    "tags": ["さいたま"],
+    "showDefault": false
   },
   {
     "name": "ヨン",
-    "tags": ["津"]
+    "tags": ["津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠しヨン",
+    "tags": ["津"],
+    "showDefault": false
   },
   {
     "name": "ご",
-    "tags": ["Usa", "コザ"]
+    "tags": ["Usa", "コザ"],
+    "showDefault": true
+  },
+  {
+    "name": "隠しご",
+    "tags": ["Usa", "コザ"],
+    "showDefault": false
   },
   {
     "name": "六",
-    "tags": ["Usa", "さいたま"]
+    "tags": ["Usa", "さいたま"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し六",
+    "tags": ["Usa", "さいたま"],
+    "showDefault": false
   },
   {
     "name": "ナナ",
-    "tags": ["Usa", "津"]
+    "tags": ["Usa", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠しナナ",
+    "tags": ["Usa", "津"],
+    "showDefault": false
   },
   {
     "name": "はち",
-    "tags": ["コザ", "さいたま"]
+    "tags": ["コザ", "さいたま"],
+    "showDefault": true
+  },
+  {
+    "name": "隠しはち",
+    "tags": ["コザ", "さいたま"],
+    "showDefault": false
   },
   {
     "name": "九",
-    "tags": ["コザ", "津"]
+    "tags": ["コザ", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し九",
+    "tags": ["コザ", "津"],
+    "showDefault": false
   },
   {
     "name": "拾",
-    "tags": ["さいたま", "津"]
+    "tags": ["さいたま", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し拾",
+    "tags": ["さいたま", "津"],
+    "showDefault": false
   },
   {
     "name": "拾イチ",
-    "tags": ["Usa", "コザ", "さいたま"]
+    "tags": ["Usa", "コザ", "さいたま"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し拾イチ",
+    "tags": ["Usa", "コザ", "さいたま"],
+    "showDefault": false
   },
   {
     "name": "拾に",
-    "tags": ["Usa", "コザ", "津"]
+    "tags": ["Usa", "コザ", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し拾に",
+    "tags": ["Usa", "コザ", "津"],
+    "showDefault": false
   },
   {
     "name": "拾三",
-    "tags": ["Usa", "さいたま", "津"]
+    "tags": ["Usa", "さいたま", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し拾三",
+    "tags": ["Usa", "さいたま", "津"],
+    "showDefault": false
   },
   {
     "name": "拾ヨン",
-    "tags": ["コザ", "さいたま", "津"]
+    "tags": ["コザ", "さいたま", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し拾ヨン",
+    "tags": ["コザ", "さいたま", "津"],
+    "showDefault": false
   },
   {
     "name": "拾ご",
-    "tags": ["Usa", "コザ", "さいたま", "津"]
+    "tags": ["Usa", "コザ", "さいたま", "津"],
+    "showDefault": true
+  },
+  {
+    "name": "隠し拾ご",
+    "tags": ["Usa", "コザ", "さいたま", "津"],
+    "showDefault": false
   }
 ]

--- a/scripts/generate-sample-characters-data.py
+++ b/scripts/generate-sample-characters-data.py
@@ -18,6 +18,12 @@ for len_count in range(len(SET_TAGS) + 1):
         characters.append({
             'name': character_name_from_count(count),
             'tags': tags,
+            'showDefault': True,
+        })
+        characters.append({
+            'name': f'隠し{character_name_from_count(count)}',
+            'tags': tags,
+            'showDefault': False,
         })
         count += 1
 

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -1,10 +1,17 @@
 import { Card, CardContent, CardHeader } from '@mui/material';
 import React from 'react';
-import { TaggedCharacter } from '../../lib/tagged-character';
 import { TagBadge } from '../atoms/TagBadge';
 import Stack from '@mui/material/Stack';
 
-interface Props extends TaggedCharacter {
+interface Props {
+  /**
+   * キャラ名
+   */
+  name: string;
+  /**
+   * タグ一覧
+   */
+  tags: string[];
   /**
    * タグクリック時のハンドラ
    * @param tag - タグ

--- a/src/components/molecules/SearchCondition.stories.tsx
+++ b/src/components/molecules/SearchCondition.stories.tsx
@@ -19,6 +19,7 @@ const componentMeta: ComponentMeta<typeof SearchCondition> = {
       },
     },
     text: { control: 'text' },
+    showAll: { control: 'boolean' },
   },
 };
 export default componentMeta;
@@ -31,4 +32,5 @@ export const Condition = Template.bind({});
 Condition.args = {
   target: SearchTarget.TAG,
   text: 'あいうえお',
+  showAll: false,
 };

--- a/src/components/molecules/SearchCondition.tsx
+++ b/src/components/molecules/SearchCondition.tsx
@@ -31,10 +31,16 @@ export const SearchCondition: React.FC<Props> = ({
   return (
     <Stack direction="row" alignItems="center" justifyContent="space-between">
       <Typography variant="h5">
-        <Typography component="span" variant="h5" fontWeight="bold">
-          {text}
-        </Typography>
-        の{targetStr}検索結果
+        {text ? (
+          <>
+            <Typography component="span" variant="h5" fontWeight="bold">
+              {text}
+            </Typography>
+            の{targetStr}検索結果
+          </>
+        ) : (
+          '検索条件なし'
+        )}
       </Typography>
       <FormGroup>
         <FormControlLabel

--- a/src/components/molecules/SearchCondition.tsx
+++ b/src/components/molecules/SearchCondition.tsx
@@ -1,21 +1,47 @@
-import { Typography } from '@mui/material';
+import {
+  FormControlLabel,
+  FormGroup,
+  Stack,
+  Switch,
+  Typography,
+} from '@mui/material';
 import React from 'react';
 import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
   target: SearchTarget;
   text: string;
+  showAll: boolean;
+  onChangeShowAll: (showAll: boolean) => void;
 }
 
-export const SearchCondition: React.FC<Props> = ({ target, text }) => {
+export const SearchCondition: React.FC<Props> = ({
+  target,
+  text,
+  showAll,
+  onChangeShowAll,
+}) => {
   const targetStr = target === SearchTarget.TAG ? 'タグ' : '名前';
+  const onChangeCheckbox: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    onChangeShowAll(event.target.checked);
+  };
 
   return (
-    <Typography variant="h5">
-      <Typography component="span" variant="h5" fontWeight="bold">
-        {text}
+    <Stack direction="row" alignItems="center" justifyContent="space-between">
+      <Typography variant="h5">
+        <Typography component="span" variant="h5" fontWeight="bold">
+          {text}
+        </Typography>
+        の{targetStr}検索結果
       </Typography>
-      の{targetStr}検索結果
-    </Typography>
+      <FormGroup>
+        <FormControlLabel
+          control={<Switch checked={showAll} onChange={onChangeCheckbox} />}
+          label="全キャラクターを表示"
+        />
+      </FormGroup>
+    </Stack>
   );
 };

--- a/src/components/organisms/CharactersSearcher.stories.tsx
+++ b/src/components/organisms/CharactersSearcher.stories.tsx
@@ -22,14 +22,17 @@ Search.args = {
     {
       name: 'Alpha',
       tags: ['あいうえお', 'かきくけこ'],
+      showDefault: true,
     },
     {
       name: 'Beta',
       tags: ['かきくけこ'],
+      showDefault: true,
     },
     {
       name: 'Gamma',
       tags: ['さしすせそ'],
+      showDefault: false,
     },
   ],
 };

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -27,16 +27,17 @@ interface SearchCondition {
 export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   const [searchTexts, setSearchTexts] = React.useState<string[]>([]);
   const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
-  const [searchResults, setSearchResults] =
-    React.useState<TaggedCharacter[]>(characters);
+  const [searchResults, setSearchResults] = React.useState<TaggedCharacter[]>(
+    characters.filter(({ showDefault }) => showDefault)
+  );
   const [searchCondition, setSearchCondition] =
     React.useState<SearchCondition | null>(null);
   const [showAll, setShowAll] = React.useState(false);
-  const search = (texts: string[], target: SearchTarget) => {
+  const search = (texts: string[], target: SearchTarget, showAll: boolean) => {
     const searchResults =
       target === SearchTarget.TAG
-        ? filterCharactersByTags(characters, texts)
-        : filterCharactersByNameWords(characters, texts);
+        ? filterCharactersByTags(characters, texts, showAll)
+        : filterCharactersByNameWords(characters, texts, showAll);
     setSearchResults(searchResults);
     setSearchCondition({
       target,
@@ -46,7 +47,11 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   const onClickTag = (tag: string) => {
     setSearchTexts([tag]);
     setSearchTarget(SearchTarget.TAG);
-    search([tag], SearchTarget.TAG);
+    search([tag], SearchTarget.TAG, showAll);
+  };
+  const onChangeShowAll = (showAll: boolean) => {
+    setShowAll(showAll);
+    search(searchTexts, searchTarget, showAll);
   };
   const autoCompleteOptions = generateAutoCompleteOptions(
     characters,
@@ -61,14 +66,14 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
         target={searchTarget}
         onChangeTarget={setSearchTarget}
         options={autoCompleteOptions}
-        onSearch={search}
+        onSearch={(texts, target) => search(texts, target, showAll)}
       />
       {searchCondition ? (
         <Box mt={2}>
           <SearchCondition
             {...searchCondition}
             showAll={showAll}
-            onChangeShowAll={setShowAll}
+            onChangeShowAll={onChangeShowAll}
           />
         </Box>
       ) : null}

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -30,8 +30,9 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   const [searchResults, setSearchResults] = React.useState<TaggedCharacter[]>(
     characters.filter(({ showDefault }) => showDefault)
   );
-  const [searchCondition, setSearchCondition] =
-    React.useState<SearchCondition | null>(null);
+  const [searchCondition, setSearchCondition] = React.useState<SearchCondition>(
+    { text: '', target: SearchTarget.TAG }
+  );
   const [showAll, setShowAll] = React.useState(false);
   const search = (texts: string[], target: SearchTarget, showAll: boolean) => {
     const searchResults =
@@ -51,7 +52,8 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   };
   const onChangeShowAll = (showAll: boolean) => {
     setShowAll(showAll);
-    search(searchTexts, searchTarget, showAll);
+    const texts = searchCondition.text ? searchCondition.text.split(' ') : [];
+    search(texts, searchCondition.target, showAll);
   };
   const autoCompleteOptions = generateAutoCompleteOptions(
     characters,
@@ -68,15 +70,13 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
         options={autoCompleteOptions}
         onSearch={(texts, target) => search(texts, target, showAll)}
       />
-      {searchCondition ? (
-        <Box mt={2}>
-          <SearchCondition
-            {...searchCondition}
-            showAll={showAll}
-            onChangeShowAll={onChangeShowAll}
-          />
-        </Box>
-      ) : null}
+      <Box mt={2}>
+        <SearchCondition
+          {...searchCondition}
+          showAll={showAll}
+          onChangeShowAll={onChangeShowAll}
+        />
+      </Box>
       <Grid container spacing={2} sx={{ mt: 1 }}>
         {searchResults.map(({ name, tags }) => (
           <Grid item key={name} xs={12} sm={6} md={4}>

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -57,7 +57,8 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
   };
   const autoCompleteOptions = generateAutoCompleteOptions(
     characters,
-    searchTarget
+    searchTarget,
+    showAll
   );
 
   return (

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -31,6 +31,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
     React.useState<TaggedCharacter[]>(characters);
   const [searchCondition, setSearchCondition] =
     React.useState<SearchCondition | null>(null);
+  const [showAll, setShowAll] = React.useState(false);
   const search = (texts: string[], target: SearchTarget) => {
     const searchResults =
       target === SearchTarget.TAG
@@ -64,7 +65,11 @@ export const CharactersSearcher: React.FC<Props> = ({ characters }) => {
       />
       {searchCondition ? (
         <Box mt={2}>
-          <SearchCondition {...searchCondition} />
+          <SearchCondition
+            {...searchCondition}
+            showAll={showAll}
+            onChangeShowAll={setShowAll}
+          />
         </Box>
       ) : null}
       <Grid container spacing={2} sx={{ mt: 1 }}>

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -7,14 +7,17 @@ describe('generateAutoCompleteOptions', () => {
     {
       name: 'Alpha',
       tags: ['x-ray', 'yankee'],
+      showDefault: true,
     },
     {
       name: 'Beta',
       tags: ['x-ray', 'zulu'],
+      showDefault: true,
     },
     {
       name: 'Gamma',
       tags: ['yankee'],
+      showDefault: true,
     },
   ];
 

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -11,29 +11,49 @@ describe('generateAutoCompleteOptions', () => {
     },
     {
       name: 'Beta',
-      tags: ['x-ray', 'zulu'],
+      tags: ['x-ray'],
       showDefault: true,
     },
     {
       name: 'Gamma',
-      tags: ['yankee'],
-      showDefault: true,
+      tags: ['zulu'],
+      showDefault: false,
     },
   ];
 
-  describe('検索対象がタグの場合', () => {
-    it('タグの一覧を重複なく返す', () => {
-      expect(generateAutoCompleteOptions(characters, SearchTarget.TAG)).toEqual(
-        ['x-ray', 'yankee', 'zulu']
-      );
+  describe('全キャラが対象の場合', () => {
+    describe('検索対象がタグの場合', () => {
+      it('タグの一覧を重複なく返す', () => {
+        expect(
+          generateAutoCompleteOptions(characters, SearchTarget.TAG, true)
+        ).toEqual(['x-ray', 'yankee', 'zulu']);
+      });
+    });
+
+    describe('検索対象がタグの場合', () => {
+      it('名前の一覧を返す', () => {
+        expect(
+          generateAutoCompleteOptions(characters, SearchTarget.NAME, true)
+        ).toEqual(['Alpha', 'Beta', 'Gamma']);
+      });
     });
   });
 
-  describe('検索対象がタグの場合', () => {
-    it('名前の一覧を返す', () => {
-      expect(
-        generateAutoCompleteOptions(characters, SearchTarget.NAME)
-      ).toEqual(['Alpha', 'Beta', 'Gamma']);
+  describe('デフォルト表示キャラのみが対象の場合', () => {
+    describe('検索対象がタグの場合', () => {
+      it('デフォルト表示キャラのタグの一覧を重複なく返す', () => {
+        expect(
+          generateAutoCompleteOptions(characters, SearchTarget.TAG, false)
+        ).toEqual(['x-ray', 'yankee']);
+      });
+    });
+
+    describe('検索対象がタグの場合', () => {
+      it('デフォルト表示キャラの名前の一覧を返す', () => {
+        expect(
+          generateAutoCompleteOptions(characters, SearchTarget.NAME, false)
+        ).toEqual(['Alpha', 'Beta']);
+      });
     });
   });
 });

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -3,12 +3,21 @@ import { SearchTarget } from './search-target';
 
 export const generateAutoCompleteOptions = (
   characters: TaggedCharacter[],
-  target: SearchTarget
+  target: SearchTarget,
+  showAll: boolean
 ): string[] => {
   switch (target) {
     case SearchTarget.TAG:
-      return Array.from(new Set(characters.flatMap(({ tags }) => tags)));
+      return Array.from(
+        new Set(
+          characters.flatMap(({ tags, showDefault }) =>
+            showAll || showDefault ? tags : []
+          )
+        )
+      );
     case SearchTarget.NAME:
-      return characters.map(({ name }) => name);
+      return characters.flatMap(({ name, showDefault }) =>
+        showAll || showDefault ? name : []
+      );
   }
 };

--- a/src/lib/load-data.spec.ts
+++ b/src/lib/load-data.spec.ts
@@ -11,6 +11,7 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 'Name',
         tags: ['test1', 'test2'],
+        showDefault: false,
       };
       expect(isTaggedCharacter(obj)).toBeTruthy();
     });
@@ -21,6 +22,7 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 1,
         tags: ['test1', 'test2'],
+        showDefault: true,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
     });
@@ -31,6 +33,7 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 'Name',
         tags: 'aaa',
+        showDefault: true,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
     });
@@ -41,6 +44,18 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 'Name',
         tags: ['test1', 2],
+        showDefault: false,
+      };
+      expect(isTaggedCharacter(obj)).toBeFalsy();
+    });
+  });
+
+  describe('showDefaultがbooleanでない場合', () => {
+    it('falseが返る', () => {
+      const obj = {
+        name: 'Name',
+        tags: ['test1', 'test2'],
+        showDefault: 1,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
     });
@@ -53,10 +68,12 @@ describe('loadCharactersDataFromJson', () => {
       {
         name: 'Alpha',
         tags: ['one', 'two'],
+        showDefault: true,
       },
       {
         name: 'Beta',
         tags: [],
+        showDefault: false,
       },
     ];
 
@@ -70,10 +87,12 @@ describe('loadCharactersDataFromJson', () => {
       {
         name: 1,
         tags: ['one, two'],
+        showDefault: true,
       },
       {
         name: 'Beta',
         tags: ['three'],
+        showDefault: true,
       },
     ];
 

--- a/src/lib/load-data.ts
+++ b/src/lib/load-data.ts
@@ -9,7 +9,8 @@ export const isTaggedCharacter = (
   return (
     typeof obj.name === 'string' &&
     Array.isArray(obj.tags) &&
-    obj.tags.every((tag) => typeof tag === 'string')
+    obj.tags.every((tag) => typeof tag === 'string') &&
+    typeof obj.showDefault === 'boolean'
   );
 };
 
@@ -20,9 +21,10 @@ export const loadCharactersDataFromJson = (
   if (!json.every(isTaggedCharacter)) {
     throw new Error('Invalid characters data');
   }
-  return json.map(({ name, tags }) => ({
+  return json.map(({ name, tags, showDefault }) => ({
     name,
     tags,
+    showDefault,
   }));
 };
 

--- a/src/lib/tagged-character.spec.ts
+++ b/src/lib/tagged-character.spec.ts
@@ -11,49 +11,92 @@ describe('filterCharactersByTag', () => {
   const alpha: TaggedCharacter = {
     name: 'alpha',
     tags: [testTag1, 'other-tag', testTag2],
+    showDefault: true,
   };
   const beta: TaggedCharacter = {
     name: 'beta',
-    tags: ['other-tag', testTag2],
+    tags: ['other-tag', testTag1],
+    showDefault: true,
   };
   const gamma: TaggedCharacter = {
     name: 'gamma',
-    tags: [testTag1],
+    tags: [testTag1, testTag2],
+    showDefault: false,
   };
   const delta: TaggedCharacter = {
     name: 'delta',
     tags: ['other-tag'],
+    showDefault: true,
   };
   const characters = [alpha, beta, gamma, delta];
 
-  describe('指定タグが1つの場合', () => {
-    it('指定タグを全て持つキャラクターの配列が返る', () => {
-      expect(filterCharactersByTags(characters, [testTag1])).toStrictEqual([
-        alpha,
-        gamma,
-      ]);
+  describe('全キャラ表示フラグがtrueの場合', () => {
+    describe('指定タグが1つの場合', () => {
+      it('指定タグを持つキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByTags(characters, [testTag1], true)
+        ).toStrictEqual([alpha, beta, gamma]);
+      });
+    });
+
+    describe('指定タグが複数の場合', () => {
+      it('指定タグを全て持つキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByTags(characters, [testTag1, testTag2], true)
+        ).toStrictEqual([alpha, gamma]);
+      });
+    });
+
+    describe('指定したタグを持つキャラクターがいない場合', () => {
+      it('空配列が返る', () => {
+        expect(
+          filterCharactersByTags(characters, ['not-set-tag'], true)
+        ).toStrictEqual([]);
+      });
+    });
+
+    describe('タグ指定がない場合', () => {
+      it('元の配列が返る', () => {
+        expect(filterCharactersByTags(characters, [], true)).toStrictEqual(
+          characters
+        );
+      });
     });
   });
 
-  describe('指定タグが複数の場合', () => {
-    it('指定タグを全て持つキャラクターの配列が返る', () => {
-      expect(
-        filterCharactersByTags(characters, [testTag1, testTag2])
-      ).toStrictEqual([alpha]);
+  describe('全キャラ表示フラグがfalseの場合', () => {
+    describe('指定タグが1つの場合', () => {
+      it('デフォルト表示され指定タグを全て持つキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByTags(characters, [testTag1], false)
+        ).toStrictEqual([alpha, beta]);
+      });
     });
-  });
 
-  describe('指定したタグを持つキャラクターがいない場合', () => {
-    it('空配列が返る', () => {
-      expect(filterCharactersByTags(characters, ['not-set-tag'])).toStrictEqual(
-        []
-      );
+    describe('指定タグが複数の場合', () => {
+      it('デフォルト表示され指定タグを全て持つキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByTags(characters, [testTag1, testTag2], false)
+        ).toStrictEqual([alpha]);
+      });
     });
-  });
 
-  describe('タグ指定がない場合', () => {
-    it('元の配列が返る', () => {
-      expect(filterCharactersByTags(characters, [])).toStrictEqual(characters);
+    describe('指定したタグを持つキャラクターがいない場合', () => {
+      it('空配列が返る', () => {
+        expect(
+          filterCharactersByTags(characters, ['not-set-tag'], true)
+        ).toStrictEqual([]);
+      });
+    });
+
+    describe('タグ指定がない場合', () => {
+      it('デフォルト表示されるキャラクターの配列が返る', () => {
+        expect(filterCharactersByTags(characters, [], false)).toStrictEqual([
+          alpha,
+          beta,
+          delta,
+        ]);
+      });
     });
   });
 });
@@ -65,18 +108,22 @@ describe('sortCharactersByTags', () => {
   const alpha: TaggedCharacter = {
     name: 'alpha',
     tags: [testTag1, 'other-tag', testTag2],
+    showDefault: true,
   };
   const beta: TaggedCharacter = {
     name: 'beta',
     tags: ['other-tag', testTag1],
+    showDefault: true,
   };
   const gamma: TaggedCharacter = {
     name: 'gamma',
     tags: [testTag3, testTag2, testTag1],
+    showDefault: true,
   };
   const delta: TaggedCharacter = {
     name: 'delta',
     tags: ['other-tag'],
+    showDefault: true,
   };
   const characters = [alpha, beta, gamma, delta];
 
@@ -107,51 +154,90 @@ describe('searchCharactersByCharacterNameWords', () => {
   const alpha: TaggedCharacter = {
     name: 'X-rayYankee',
     tags: [],
+    showDefault: true,
   };
   const beta: TaggedCharacter = {
-    name: 'Zulu',
+    name: 'ZuluX-ray',
     tags: [],
+    showDefault: true,
   };
   const gamma: TaggedCharacter = {
-    name: 'X-rayOther',
+    name: 'X-rayOtherYankee',
     tags: [],
+    showDefault: false,
   };
   const delta: TaggedCharacter = {
     name: 'Other',
     tags: [],
+    showDefault: true,
   };
   const characters = [alpha, beta, gamma, delta];
 
-  describe('キーワードが1つの場合', () => {
-    it('キーワードを名前に含むキャラクターの配列が返る', () => {
-      expect(filterCharactersByNameWords(characters, ['X-ray'])).toStrictEqual([
-        alpha,
-        gamma,
-      ]);
+  describe('全キャラ表示フラグがtrueの場合', () => {
+    describe('キーワードが1つの場合', () => {
+      it('キーワードを名前に含むキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, ['X-ray'], true)
+        ).toStrictEqual([alpha, beta, gamma]);
+      });
+    });
+
+    describe('キーワードが複数の場合', () => {
+      it('キーワードを全て名前に含むキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, ['X-ray', 'Yankee'], true)
+        ).toStrictEqual([alpha, gamma]);
+      });
+    });
+
+    describe('キーワードがヒットしない場合', () => {
+      it('空配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, ['not-included-word'], true)
+        ).toStrictEqual([]);
+      });
+    });
+
+    describe('キーワード指定がない場合', () => {
+      it('元の配列が返る', () => {
+        expect(filterCharactersByNameWords(characters, [], true)).toStrictEqual(
+          characters
+        );
+      });
     });
   });
 
-  describe('キーワードが複数の場合', () => {
-    it('キーワードを全て名前に含むキャラクターの配列が返る', () => {
-      expect(
-        filterCharactersByNameWords(characters, ['X-ray', 'Yankee'])
-      ).toStrictEqual([alpha]);
+  describe('全キャラ表示フラグがfalseの場合', () => {
+    describe('キーワードが1つの場合', () => {
+      it('キーワードを名前に含むキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, ['X-ray'], false)
+        ).toStrictEqual([alpha, beta]);
+      });
     });
-  });
 
-  describe('キーワードがヒットしない場合', () => {
-    it('空配列が返る', () => {
-      expect(
-        filterCharactersByNameWords(characters, ['not-included-word'])
-      ).toStrictEqual([]);
+    describe('キーワードが複数の場合', () => {
+      it('キーワードを全て名前に含むキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, ['X-ray', 'Yankee'], false)
+        ).toStrictEqual([alpha]);
+      });
     });
-  });
 
-  describe('キーワード指定がない場合', () => {
-    it('元の配列が返る', () => {
-      expect(filterCharactersByNameWords(characters, [])).toStrictEqual(
-        characters
-      );
+    describe('キーワードがヒットしない場合', () => {
+      it('空配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, ['not-included-word'], false)
+        ).toStrictEqual([]);
+      });
+    });
+
+    describe('キーワード指定がない場合', () => {
+      it('デフォルト表示されるキャラクターの配列が返る', () => {
+        expect(
+          filterCharactersByNameWords(characters, [], false)
+        ).toStrictEqual([alpha, beta, delta]);
+      });
     });
   });
 });

--- a/src/lib/tagged-character.spec.ts
+++ b/src/lib/tagged-character.spec.ts
@@ -1,5 +1,4 @@
 import {
-  sortCharactersByTags,
   filterCharactersByTags,
   TaggedCharacter,
   filterCharactersByNameWords,
@@ -97,55 +96,6 @@ describe('filterCharactersByTag', () => {
           delta,
         ]);
       });
-    });
-  });
-});
-
-describe('sortCharactersByTags', () => {
-  const testTag1 = 'x-ray';
-  const testTag2 = 'yankee';
-  const testTag3 = 'zulu';
-  const alpha: TaggedCharacter = {
-    name: 'alpha',
-    tags: [testTag1, 'other-tag', testTag2],
-    showDefault: true,
-  };
-  const beta: TaggedCharacter = {
-    name: 'beta',
-    tags: ['other-tag', testTag1],
-    showDefault: true,
-  };
-  const gamma: TaggedCharacter = {
-    name: 'gamma',
-    tags: [testTag3, testTag2, testTag1],
-    showDefault: true,
-  };
-  const delta: TaggedCharacter = {
-    name: 'delta',
-    tags: ['other-tag'],
-    showDefault: true,
-  };
-  const characters = [alpha, beta, gamma, delta];
-
-  describe('タグがヒットする場合', () => {
-    it('ヒットしたタグが多い順にキャラクターの配列が返る', () => {
-      expect(
-        sortCharactersByTags(characters, [testTag1, testTag2, testTag3])
-      ).toStrictEqual([gamma, alpha, beta, delta]);
-    });
-  });
-
-  describe('指定したタグを持つキャラクターがいない場合', () => {
-    it('元の配列が返る', () => {
-      expect(sortCharactersByTags(characters, ['not-set-tag'])).toStrictEqual(
-        characters
-      );
-    });
-  });
-
-  describe('タグが指定されない場合', () => {
-    it('元の配列が返る', () => {
-      expect(sortCharactersByTags(characters, [])).toStrictEqual(characters);
     });
   });
 });

--- a/src/lib/tagged-character.ts
+++ b/src/lib/tagged-character.ts
@@ -8,10 +8,14 @@ export interface TaggedCharacter {
 
 export const filterCharactersByTags = (
   characters: TaggedCharacter[],
-  tags: Tag[]
+  tags: Tag[],
+  showAll: boolean
 ): TaggedCharacter[] => {
   return characters.filter((character) => {
-    return tags.every((tag) => character.tags.includes(tag));
+    return (
+      (showAll || character.showDefault) &&
+      tags.every((tag) => character.tags.includes(tag))
+    );
   });
 };
 
@@ -34,9 +38,12 @@ export const sortCharactersByTags = (
 
 export const filterCharactersByNameWords = (
   characters: TaggedCharacter[],
-  nameWords: string[]
+  nameWords: string[],
+  showAll: boolean
 ): TaggedCharacter[] => {
-  return characters.filter(({ name }) =>
-    nameWords.every((word) => name.includes(word))
-  );
+  return characters.filter(({ name, showDefault }) => {
+    return (
+      (showAll || showDefault) && nameWords.every((word) => name.includes(word))
+    );
+  });
 };

--- a/src/lib/tagged-character.ts
+++ b/src/lib/tagged-character.ts
@@ -19,23 +19,6 @@ export const filterCharactersByTags = (
   });
 };
 
-export const sortCharactersByTags = (
-  characters: TaggedCharacter[],
-  tags: Tag[]
-): TaggedCharacter[] => {
-  const matchedTagsCounts = characters.flatMap((character) => {
-    const matchedCount = tags.filter((tag) =>
-      character.tags.includes(tag)
-    ).length;
-    return {
-      character,
-      count: matchedCount,
-    };
-  });
-  matchedTagsCounts.sort((a, b) => b.count - a.count);
-  return matchedTagsCounts.map(({ character }) => character);
-};
-
 export const filterCharactersByNameWords = (
   characters: TaggedCharacter[],
   nameWords: string[],

--- a/src/lib/tagged-character.ts
+++ b/src/lib/tagged-character.ts
@@ -3,6 +3,7 @@ export type Tag = string;
 export interface TaggedCharacter {
   name: string;
   tags: Tag[];
+  showDefault: boolean;
 }
 
 export const filterCharactersByTags = (


### PR DESCRIPTION
Resolve #32 

- `showDefault` が `true` のキャラクターはデフォルトで表示
- 全キャラ表示スイッチがあり、ONになるとデフォルト非表示キャラも含めて表示する
- 検索していない状態でも検索条件を表示する
    - 指定ない状態では「検索条件なし」になる
- おまけ: タグの一致数でソートする関数を削除

画面スクショ

| 一部だけ表示 | 全キャラ表示 |
| - | - |
| <img width="1196" alt="image" src="https://user-images.githubusercontent.com/7444623/184545718-5d5444b7-3fa6-4881-8767-c133f28f4e95.png"> | <img width="1197" alt="image" src="https://user-images.githubusercontent.com/7444623/184545732-1c5b855f-c8ef-40be-8060-cffd18a51f2e.png"> |

