### PR TITLE
名前やタグを入力したら自動検索する

### DIFF
--- a/src/components/molecules/SearchCondition.stories.tsx
+++ b/src/components/molecules/SearchCondition.stories.tsx
@@ -18,7 +18,7 @@ const componentMeta: ComponentMeta<typeof SearchCondition> = {
         },
       },
     },
-    text: { control: 'text' },
+    texts: { control: 'object' },
     showAll: { control: 'boolean' },
     sx: { control: 'object' },
   },
@@ -32,7 +32,7 @@ const Template: ComponentStory<typeof SearchCondition> = (args) => (
 export const Condition = Template.bind({});
 Condition.args = {
   target: SearchTarget.TAG,
-  text: 'あいうえお',
+  texts: ['あいうえお'],
   showAll: false,
   sx: {},
 };

--- a/src/components/molecules/SearchCondition.tsx
+++ b/src/components/molecules/SearchCondition.tsx
@@ -18,7 +18,7 @@ interface Props {
   /**
    * 検索文字列
    */
-  text: string;
+  texts: string[];
   /**
    * 全キャラ表示フラグ
    */
@@ -35,7 +35,7 @@ interface Props {
 
 export const SearchCondition: React.FC<Props> = ({
   target,
-  text,
+  texts,
   showAll,
   onChangeShowAll,
   sx,
@@ -46,6 +46,7 @@ export const SearchCondition: React.FC<Props> = ({
   ) => {
     onChangeShowAll(event.target.checked);
   };
+  const joinedText = texts.join(' ');
 
   return (
     <Stack
@@ -55,10 +56,10 @@ export const SearchCondition: React.FC<Props> = ({
       sx={sx}
     >
       <Typography variant="h5">
-        {text ? (
+        {joinedText ? (
           <>
             <Typography component="span" variant="h5" fontWeight="bold">
-              {text}
+              {joinedText}
             </Typography>
             の{targetStr}検索結果
           </>

--- a/src/components/molecules/SearchForm.stories.tsx
+++ b/src/components/molecules/SearchForm.stories.tsx
@@ -8,7 +8,6 @@ const componentMeta: ComponentMeta<typeof SearchForm> = {
   title: 'Molecules/SearchForm',
   component: SearchForm,
   argTypes: {
-    texts: { control: 'object' },
     target: {
       options: [SearchTarget.TAG, SearchTarget.NAME],
       control: {
@@ -19,6 +18,7 @@ const componentMeta: ComponentMeta<typeof SearchForm> = {
         },
       },
     },
+    texts: { control: 'object' },
     autocompleteOptions: { control: 'object' },
     sx: { control: 'object' },
   },
@@ -31,8 +31,8 @@ const Template: ComponentStory<typeof SearchForm> = (args) => (
 
 export const Search = Template.bind({});
 Search.args = {
-  texts: [],
   target: SearchTarget.TAG,
+  texts: [],
   autocompleteOptions: ['あいうえお', 'かきくけこ'],
   sx: {},
 };

--- a/src/components/molecules/SearchForm.stories.tsx
+++ b/src/components/molecules/SearchForm.stories.tsx
@@ -19,7 +19,7 @@ const componentMeta: ComponentMeta<typeof SearchForm> = {
         },
       },
     },
-    options: { control: 'object' },
+    autocompleteOptions: { control: 'object' },
     sx: { control: 'object' },
   },
 };
@@ -33,6 +33,6 @@ export const Search = Template.bind({});
 Search.args = {
   texts: [],
   target: SearchTarget.TAG,
-  options: ['あいうえお', 'かきくけこ'],
+  autocompleteOptions: ['あいうえお', 'かきくけこ'],
   sx: {},
 };

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -28,7 +28,7 @@ interface Props {
   /**
    * 検索ワードの補完候補
    */
-  options: string[];
+  autocompleteOptions: string[];
   /**
    * テーマ関係のスタイル指定
    */
@@ -40,7 +40,7 @@ export const SearchForm: React.FC<Props> = ({
   onChangeTexts,
   target,
   onChangeTarget,
-  options,
+  autocompleteOptions,
   sx,
 }) => {
   const onTextChange = (_, texts: string[]) => onChangeTexts(texts);
@@ -62,7 +62,7 @@ export const SearchForm: React.FC<Props> = ({
         onChange={onTextChange}
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする
-        options={options}
+        options={autocompleteOptions}
         fullWidth
         renderInput={(params) => (
           <TextField

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -8,15 +8,6 @@ import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
   /**
-   * 検索文字列
-   */
-  texts: string[];
-  /**
-   * 検索文字列の変更ハンドラ
-   * @param texts - 変更後の検索文字列
-   */
-  onChangeTexts: (texts: string[]) => void;
-  /**
    * 検索対象
    */
   target: SearchTarget;
@@ -25,6 +16,15 @@ interface Props {
    * @param target - 変更後の検索対象
    */
   onChangeTarget: (target: SearchTarget) => void;
+  /**
+   * 検索文字列
+   */
+  texts: string[];
+  /**
+   * 検索文字列の変更ハンドラ
+   * @param texts - 変更後の検索文字列
+   */
+  onChangeTexts: (texts: string[]) => void;
   /**
    * 検索ワードの補完候補
    */
@@ -36,10 +36,10 @@ interface Props {
 }
 
 export const SearchForm: React.FC<Props> = ({
-  texts,
-  onChangeTexts,
   target,
   onChangeTarget,
+  texts,
+  onChangeTexts,
   autocompleteOptions,
   sx,
 }) => {

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -1,7 +1,5 @@
-import React, { FormEventHandler } from 'react';
-import IconButton from '@mui/material/IconButton';
+import React from 'react';
 import Box from '@mui/material/Box';
-import SearchIcon from '@mui/icons-material/Search';
 import { SxProps, Theme, useTheme } from '@mui/material/styles';
 import { SearchTargetSelect } from './SearchTargetSelect';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -32,11 +30,6 @@ interface Props {
    */
   options: string[];
   /**
-   * 検索イベントのハンドラー
-   * @param text - 検索文字列
-   */
-  onSearch: (texts: string[], target: SearchTarget) => void;
-  /**
    * テーマ関係のスタイル指定
    */
   sx?: SxProps<Theme>;
@@ -48,23 +41,15 @@ export const SearchForm: React.FC<Props> = ({
   target,
   onChangeTarget,
   options,
-  onSearch,
   sx,
 }) => {
   const onTextChange = (_, texts: string[]) => onChangeTexts(texts);
-  const startSearch: FormEventHandler<HTMLFormElement> = (event) => {
-    event.preventDefault();
-    if (texts.length > 0) {
-      onSearch(texts, target);
-    }
-  };
   const theme = useTheme();
   const placeholder = `${target === SearchTarget.TAG ? 'タグ' : '名前'}を入力`;
 
   return (
     <Box
       component="form"
-      onSubmit={startSearch}
       sx={{ display: 'flex', alignItems: 'center', ...sx }}
     >
       <SearchTargetSelect target={target} onChange={onChangeTarget} />
@@ -104,9 +89,6 @@ export const SearchForm: React.FC<Props> = ({
         }
         sx={{ ml: 2 }}
       />
-      <IconButton type="submit" sx={{ ml: 1 }}>
-        <SearchIcon fontSize="large" />
-      </IconButton>
     </Box>
   );
 };

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -48,10 +48,7 @@ export const SearchForm: React.FC<Props> = ({
   const placeholder = `${target === SearchTarget.TAG ? 'タグ' : '名前'}を入力`;
 
   return (
-    <Box
-      component="form"
-      sx={{ display: 'flex', alignItems: 'center', ...sx }}
-    >
+    <Box component="form" sx={{ display: 'flex', alignItems: 'center', ...sx }}>
       <SearchTargetSelect target={target} onChange={onChangeTarget} />
       <Autocomplete
         autoComplete

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -9,7 +9,7 @@ import { CharacterCard } from '../molecules/CharacterCard';
 import { SearchForm } from '../molecules/SearchForm';
 import Box from '@mui/material/Box';
 import { SearchCondition } from '../molecules/SearchCondition';
-import { generateAutoCompleteOptions } from '../../lib/autocomplete';
+import { generateAutocompleteOptions } from '../../lib/autocomplete';
 import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
@@ -67,7 +67,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
     setSearchTarget(newTarget);
     search(searchTexts, newTarget, showAll);
   }
-  const autocompleteOptions = generateAutoCompleteOptions(
+  const autocompleteOptions = generateAutocompleteOptions(
     characters,
     searchTarget,
     showAll

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -23,19 +23,11 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-interface SearchCondition {
-  target: SearchTarget;
-  text: string;
-}
-
 export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
   const [searchTexts, setSearchTexts] = React.useState<string[]>([]);
   const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
   const [searchResults, setSearchResults] = React.useState<TaggedCharacter[]>(
     characters.filter(({ showDefault }) => showDefault)
-  );
-  const [searchCondition, setSearchCondition] = React.useState<SearchCondition>(
-    { text: '', target: SearchTarget.TAG }
   );
   const [showAll, setShowAll] = React.useState(false);
   const search = (texts: string[], target: SearchTarget, showAll: boolean) => {
@@ -44,10 +36,6 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
         ? filterCharactersByTags(characters, texts, showAll)
         : filterCharactersByNameWords(characters, texts, showAll);
     setSearchResults(searchResults);
-    setSearchCondition({
-      target,
-      text: texts.join(' '),
-    });
   };
   const onClickTag = (tag: string) => {
     setSearchTexts([tag]);
@@ -56,8 +44,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
   };
   const onChangeShowAll = (showAll: boolean) => {
     setShowAll(showAll);
-    const texts = searchCondition.text ? searchCondition.text.split(' ') : [];
-    search(texts, searchCondition.target, showAll);
+    search(searchTexts, searchTarget, showAll);
   };
   const onChangeSearchTexts = (newTexts: string[]) => {
     setSearchTexts(newTexts);
@@ -65,7 +52,8 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
   };
   const onChangeSearchTarget = (newTarget: SearchTarget) => {
     setSearchTarget(newTarget);
-    search(searchTexts, newTarget, showAll);
+    setSearchTexts([]);
+    search([], newTarget, showAll);
   };
   const autocompleteOptions = generateAutocompleteOptions(
     characters,
@@ -83,7 +71,8 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
         autocompleteOptions={autocompleteOptions}
       />
       <SearchCondition
-        {...searchCondition}
+        texts={searchTexts}
+        target={searchTarget}
         showAll={showAll}
         onChangeShowAll={onChangeShowAll}
         sx={{ mt: 2 }}

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -67,7 +67,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
     setSearchTarget(newTarget);
     search(searchTexts, newTarget, showAll);
   }
-  const autoCompleteOptions = generateAutoCompleteOptions(
+  const autocompleteOptions = generateAutoCompleteOptions(
     characters,
     searchTarget,
     showAll
@@ -80,7 +80,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
         onChangeTexts={onChangeSearchTexts}
         target={searchTarget}
         onChangeTarget={onChangeSearchTarget}
-        options={autoCompleteOptions}
+        autocompleteOptions={autocompleteOptions}
       />
       <SearchCondition
         {...searchCondition}

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -81,7 +81,6 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
         target={searchTarget}
         onChangeTarget={onChangeSearchTarget}
         options={autoCompleteOptions}
-        onSearch={(texts, target) => search(texts, target, showAll)}
       />
       <SearchCondition
         {...searchCondition}

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -24,37 +24,40 @@ interface Props {
 }
 
 export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
-  const [searchTexts, setSearchTexts] = React.useState<string[]>([]);
-  const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
   const [searchResults, setSearchResults] = React.useState<TaggedCharacter[]>(
     characters.filter(({ showDefault }) => showDefault)
   );
-  const [showAll, setShowAll] = React.useState(false);
-  const search = (texts: string[], target: SearchTarget, showAll: boolean) => {
+  const search = (target: SearchTarget, texts: string[], showAll: boolean) => {
     const searchResults =
       target === SearchTarget.TAG
         ? filterCharactersByTags(characters, texts, showAll)
         : filterCharactersByNameWords(characters, texts, showAll);
     setSearchResults(searchResults);
   };
-  const onClickTag = (tag: string) => {
-    setSearchTexts([tag]);
-    setSearchTarget(SearchTarget.TAG);
-    search([tag], SearchTarget.TAG, showAll);
-  };
-  const onChangeShowAll = (showAll: boolean) => {
-    setShowAll(showAll);
-    search(searchTexts, searchTarget, showAll);
-  };
-  const onChangeSearchTexts = (newTexts: string[]) => {
-    setSearchTexts(newTexts);
-    search(newTexts, searchTarget, showAll);
-  };
+
+  const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
+  const [searchTexts, setSearchTexts] = React.useState<string[]>([]);
+  const [showAll, setShowAll] = React.useState(false);
+
   const onChangeSearchTarget = (newTarget: SearchTarget) => {
     setSearchTarget(newTarget);
     setSearchTexts([]);
-    search([], newTarget, showAll);
+    search(newTarget, [], showAll);
   };
+  const onChangeSearchTexts = (newTexts: string[]) => {
+    setSearchTexts(newTexts);
+    search(searchTarget, newTexts, showAll);
+  };
+  const onChangeShowAll = (showAll: boolean) => {
+    setShowAll(showAll);
+    search(searchTarget, searchTexts, showAll);
+  };
+  const onClickTag = (tag: string) => {
+    setSearchTexts([tag]);
+    setSearchTarget(SearchTarget.TAG);
+    search(SearchTarget.TAG, [tag], showAll);
+  };
+
   const autocompleteOptions = generateAutocompleteOptions(
     characters,
     searchTarget,
@@ -64,15 +67,15 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
   return (
     <Box sx={sx}>
       <SearchForm
-        texts={searchTexts}
-        onChangeTexts={onChangeSearchTexts}
         target={searchTarget}
         onChangeTarget={onChangeSearchTarget}
+        texts={searchTexts}
+        onChangeTexts={onChangeSearchTexts}
         autocompleteOptions={autocompleteOptions}
       />
       <SearchCondition
-        texts={searchTexts}
         target={searchTarget}
+        texts={searchTexts}
         showAll={showAll}
         onChangeShowAll={onChangeShowAll}
         sx={{ mt: 2 }}

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -59,6 +59,14 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
     const texts = searchCondition.text ? searchCondition.text.split(' ') : [];
     search(texts, searchCondition.target, showAll);
   };
+  const onChangeSearchTexts = (newTexts: string[]) => {
+    setSearchTexts(newTexts);
+    search(newTexts, searchTarget, showAll);
+  }
+  const onChangeSearchTarget = (newTarget: SearchTarget) => {
+    setSearchTarget(newTarget);
+    search(searchTexts, newTarget, showAll);
+  }
   const autoCompleteOptions = generateAutoCompleteOptions(
     characters,
     searchTarget,
@@ -69,9 +77,9 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
     <Box sx={sx}>
       <SearchForm
         texts={searchTexts}
-        onChangeTexts={setSearchTexts}
+        onChangeTexts={onChangeSearchTexts}
         target={searchTarget}
-        onChangeTarget={setSearchTarget}
+        onChangeTarget={onChangeSearchTarget}
         options={autoCompleteOptions}
         onSearch={(texts, target) => search(texts, target, showAll)}
       />

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -62,11 +62,11 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
   const onChangeSearchTexts = (newTexts: string[]) => {
     setSearchTexts(newTexts);
     search(newTexts, searchTarget, showAll);
-  }
+  };
   const onChangeSearchTarget = (newTarget: SearchTarget) => {
     setSearchTarget(newTarget);
     search(searchTexts, newTarget, showAll);
-  }
+  };
   const autocompleteOptions = generateAutocompleteOptions(
     characters,
     searchTarget,

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -1,8 +1,8 @@
-import { generateAutoCompleteOptions } from './autocomplete';
+import { generateAutocompleteOptions } from './autocomplete';
 import { SearchTarget } from './search-target';
 import { TaggedCharacter } from './tagged-character';
 
-describe('generateAutoCompleteOptions', () => {
+describe('generateAutocompleteOptions', () => {
   const characters: TaggedCharacter[] = [
     {
       name: 'Alpha',
@@ -25,7 +25,7 @@ describe('generateAutoCompleteOptions', () => {
     describe('検索対象がタグの場合', () => {
       it('タグの一覧を重複なく返す', () => {
         expect(
-          generateAutoCompleteOptions(characters, SearchTarget.TAG, true)
+          generateAutocompleteOptions(characters, SearchTarget.TAG, true)
         ).toEqual(['x-ray', 'yankee', 'zulu']);
       });
     });
@@ -33,7 +33,7 @@ describe('generateAutoCompleteOptions', () => {
     describe('検索対象がタグの場合', () => {
       it('名前の一覧を返す', () => {
         expect(
-          generateAutoCompleteOptions(characters, SearchTarget.NAME, true)
+          generateAutocompleteOptions(characters, SearchTarget.NAME, true)
         ).toEqual(['Alpha', 'Beta', 'Gamma']);
       });
     });
@@ -43,7 +43,7 @@ describe('generateAutoCompleteOptions', () => {
     describe('検索対象がタグの場合', () => {
       it('デフォルト表示キャラのタグの一覧を重複なく返す', () => {
         expect(
-          generateAutoCompleteOptions(characters, SearchTarget.TAG, false)
+          generateAutocompleteOptions(characters, SearchTarget.TAG, false)
         ).toEqual(['x-ray', 'yankee']);
       });
     });
@@ -51,7 +51,7 @@ describe('generateAutoCompleteOptions', () => {
     describe('検索対象がタグの場合', () => {
       it('デフォルト表示キャラの名前の一覧を返す', () => {
         expect(
-          generateAutoCompleteOptions(characters, SearchTarget.NAME, false)
+          generateAutocompleteOptions(characters, SearchTarget.NAME, false)
         ).toEqual(['Alpha', 'Beta']);
       });
     });

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -1,7 +1,7 @@
 import { TaggedCharacter } from './tagged-character';
 import { SearchTarget } from './search-target';
 
-export const generateAutoCompleteOptions = (
+export const generateAutocompleteOptions = (
   characters: TaggedCharacter[],
   target: SearchTarget,
   showAll: boolean


### PR DESCRIPTION
Resolve #33 

- 検索ワードが確定した時点(補完候補などでEnterを押した時点)で自動検索する
- 検索ボタンの削除
- (おまけ) `autocomplete` `auto complete` で分かれていた単語の区切りを `autocomplete` に統一
- (おまけ)検索対象を切り替える際は検索文字列をリセットする
- (おまけ)検索関連の変数の順番を対象→ワード→全キャラ表示フラグの順に統一