### PR TITLE
タグにカテゴリをつけて補完候補をグルーピングする

### DIFF
--- a/sample/characters-data/sample.json
+++ b/sample/characters-data/sample.json
@@ -11,152 +11,438 @@
   },
   {
     "name": "イチ",
-    "tags": ["Usa"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠しイチ",
-    "tags": ["Usa"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "に",
-    "tags": ["コザ"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠しに",
-    "tags": ["コザ"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "三",
-    "tags": ["さいたま"],
+    "tags": [
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し三",
-    "tags": ["さいたま"],
+    "tags": [
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "ヨン",
-    "tags": ["津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠しヨン",
-    "tags": ["津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "ご",
-    "tags": ["Usa", "コザ"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠しご",
-    "tags": ["Usa", "コザ"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "六",
-    "tags": ["Usa", "さいたま"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し六",
-    "tags": ["Usa", "さいたま"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "ナナ",
-    "tags": ["Usa", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠しナナ",
-    "tags": ["Usa", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "はち",
-    "tags": ["コザ", "さいたま"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠しはち",
-    "tags": ["コザ", "さいたま"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "九",
-    "tags": ["コザ", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し九",
-    "tags": ["コザ", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "拾",
-    "tags": ["さいたま", "津"],
+    "tags": [
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し拾",
-    "tags": ["さいたま", "津"],
+    "tags": [
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "拾イチ",
-    "tags": ["Usa", "コザ", "さいたま"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し拾イチ",
-    "tags": ["Usa", "コザ", "さいたま"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "拾に",
-    "tags": ["Usa", "コザ", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し拾に",
-    "tags": ["Usa", "コザ", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "拾三",
-    "tags": ["Usa", "さいたま", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し拾三",
-    "tags": ["Usa", "さいたま", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "拾ヨン",
-    "tags": ["コザ", "さいたま", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し拾ヨン",
-    "tags": ["コザ", "さいたま", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   },
   {
     "name": "拾ご",
-    "tags": ["Usa", "コザ", "さいたま", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": true
   },
   {
     "name": "隠し拾ご",
-    "tags": ["Usa", "コザ", "さいたま", "津"],
+    "tags": [
+      {
+        "category": "西日本",
+        "name": "Usa"
+      },
+      {
+        "category": "西日本",
+        "name": "コザ"
+      },
+      {
+        "category": "東日本",
+        "name": "さいたま"
+      },
+      {
+        "category": "西日本",
+        "name": "津"
+      }
+    ],
     "showDefault": false
   }
 ]

--- a/sample/characters-data/sample.json
+++ b/sample/characters-data/sample.json
@@ -14,7 +14,7 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       }
     ],
     "showDefault": true
@@ -24,7 +24,7 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       }
     ],
     "showDefault": false
@@ -34,7 +34,7 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       }
     ],
     "showDefault": true
@@ -44,7 +44,7 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       }
     ],
     "showDefault": false
@@ -54,7 +54,7 @@
     "tags": [
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": true
@@ -64,7 +64,7 @@
     "tags": [
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": false
@@ -74,7 +74,7 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -84,7 +84,7 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -94,11 +94,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       }
     ],
     "showDefault": true
@@ -108,11 +108,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       }
     ],
     "showDefault": false
@@ -122,11 +122,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": true
@@ -136,11 +136,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": false
@@ -150,11 +150,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -164,11 +164,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -178,11 +178,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": true
@@ -192,11 +192,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": false
@@ -206,11 +206,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -220,11 +220,11 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -234,11 +234,11 @@
     "tags": [
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -248,11 +248,11 @@
     "tags": [
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -262,15 +262,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": true
@@ -280,15 +280,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       }
     ],
     "showDefault": false
@@ -298,15 +298,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -316,15 +316,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -334,15 +334,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -352,15 +352,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -370,15 +370,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -388,15 +388,15 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false
@@ -406,19 +406,19 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": true
@@ -428,19 +428,19 @@
     "tags": [
       {
         "category": "西日本",
-        "name": "Usa"
+        "label": "Usa"
       },
       {
         "category": "西日本",
-        "name": "コザ"
+        "label": "コザ"
       },
       {
         "category": "東日本",
-        "name": "さいたま"
+        "label": "さいたま"
       },
       {
         "category": "西日本",
-        "name": "津"
+        "label": "津"
       }
     ],
     "showDefault": false

--- a/scripts/generate-sample-characters-data.py
+++ b/scripts/generate-sample-characters-data.py
@@ -10,10 +10,10 @@ def character_name_from_count(count):
 
 
 SET_TAGS = [
-    {'category': '西日本', 'name': 'Usa'},
-    {'category': '西日本', 'name': 'コザ'},
-    {'category': '東日本', 'name': 'さいたま'},
-    {'category': '西日本', 'name': '津'},
+    {'category': '西日本', 'label': 'Usa'},
+    {'category': '西日本', 'label': 'コザ'},
+    {'category': '東日本', 'label': 'さいたま'},
+    {'category': '西日本', 'label': '津'},
 ]
 count = 0
 # タグの組み合わせを全パターン出す

--- a/scripts/generate-sample-characters-data.py
+++ b/scripts/generate-sample-characters-data.py
@@ -9,7 +9,12 @@ def character_name_from_count(count):
     return JAPANESE_NAME[count]
 
 
-SET_TAGS = ['Usa', 'コザ', 'さいたま', '津']
+SET_TAGS = [
+    {'category': '西日本', 'name': 'Usa'},
+    {'category': '西日本', 'name': 'コザ'},
+    {'category': '東日本', 'name': 'さいたま'},
+    {'category': '西日本', 'name': '津'},
+]
 count = 0
 # タグの組み合わせを全パターン出す
 characters = []

--- a/src/components/molecules/CharacterCard.stories.tsx
+++ b/src/components/molecules/CharacterCard.stories.tsx
@@ -8,7 +8,7 @@ const componentMeta: ComponentMeta<typeof CharacterCard> = {
   component: CharacterCard,
   argTypes: {
     name: { control: 'text' },
-    tags: { control: 'object' },
+    tagLabels: { control: 'object' },
     sx: { control: 'object' },
   },
 };
@@ -21,6 +21,6 @@ const Template: ComponentStory<typeof CharacterCard> = (args) => (
 export const Card = Template.bind({});
 Card.args = {
   name: 'なまえ',
-  tags: ['タグ1', 'タグ2'],
+  tagLabels: ['タグ1', 'タグ2'],
   sx: {},
 };

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -11,12 +11,12 @@ interface Props {
   /**
    * タグ一覧
    */
-  tags: string[];
+  tagLabels: string[];
   /**
    * タグクリック時のハンドラ
-   * @param tag - タグ
+   * @param tagLabel - タグ
    */
-  onClickTag: (tag: string) => void;
+  onClickTag: (tagLabel: string) => void;
   /**
    * テーマ関係のスタイル指定
    */
@@ -25,7 +25,7 @@ interface Props {
 
 export const CharacterCard: React.FC<Props> = ({
   name,
-  tags,
+  tagLabels,
   onClickTag,
   sx,
 }) => (
@@ -37,9 +37,9 @@ export const CharacterCard: React.FC<Props> = ({
         spacing={1}
         sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
       >
-        {tags.map((tag) => (
-          <TagBadge key={tag} onClick={onClickTag}>
-            {tag}
+        {tagLabels.map((tagLabel) => (
+          <TagBadge key={tagLabel} onClick={onClickTag}>
+            {tagLabel}
           </TagBadge>
         ))}
       </Stack>

--- a/src/components/molecules/SearchForm.stories.tsx
+++ b/src/components/molecules/SearchForm.stories.tsx
@@ -33,6 +33,9 @@ export const Search = Template.bind({});
 Search.args = {
   target: SearchTarget.TAG,
   texts: [],
-  autocompleteOptions: ['あいうえお', 'かきくけこ'],
+  autocompleteOptions: [
+    { category: 'あ行', label: 'あいうえお' },
+    { category: 'か行', label: 'かきくけこ' },
+  ],
   sx: {},
 };

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -61,7 +61,11 @@ export const SearchForm: React.FC<Props> = ({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする
         options={autocompleteOptions}
-        groupBy={target === SearchTarget.TAG ? (option: Tag) => option.category : undefined}
+        groupBy={
+          target === SearchTarget.TAG
+            ? (option: Tag) => option.category
+            : undefined
+        }
         fullWidth
         renderInput={(params) => (
           <TextField

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -61,6 +61,7 @@ export const SearchForm: React.FC<Props> = ({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする
         options={autocompleteOptions}
+        groupBy={target === SearchTarget.TAG ? (option: Tag) => option.category : undefined}
         fullWidth
         renderInput={(params) => (
           <TextField

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -63,8 +63,6 @@ export const SearchForm: React.FC<Props> = ({
         filterSelectedOptions
         value={texts}
         onChange={onTextChange}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore optionsの要求型が明らかにおかしいから一時的にignoreする
         options={autocompleteOptions}
         groupBy={
           target === SearchTarget.TAG
@@ -86,13 +84,11 @@ export const SearchForm: React.FC<Props> = ({
             }}
           />
         )}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore valueの要求型が明らかにおかしいから一時的にignoreする
-        renderTags={(value: string[], getTagProps) =>
-          value.map((option: string, index: number) => (
+        renderTags={(values: string[], getTagProps) =>
+          values.map((value, index) => (
             <Chip
-              key={option}
-              label={option}
+              key={value}
+              label={value}
               {...getTagProps({ index })}
               sx={{ fontSize: theme.typography.h6 }}
             />

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -66,6 +66,13 @@ export const SearchForm: React.FC<Props> = ({
             ? (option: Tag) => option.category
             : undefined
         }
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore valueの要求型が明らかにおかしいから一時的にignoreする
+        isOptionEqualToValue={
+          target === SearchTarget.TAG
+            ? (option: Tag, value: string) => option.label === value
+            : undefined
+        }
         fullWidth
         renderInput={(params) => (
           <TextField

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -44,7 +44,9 @@ export const SearchForm: React.FC<Props> = ({
   autocompleteOptions,
   sx,
 }) => {
-  const onTextChange = (_, texts: string[]) => onChangeTexts(texts);
+  const onTextChange = (_, texts: (string | Tag)[]) => {
+    onChangeTexts(texts.map((text) => typeof text === 'string' ? text : text.label));
+  }
   const theme = useTheme();
   const placeholder = `${target === SearchTarget.TAG ? 'タグ' : '名前'}を入力`;
 

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -6,6 +6,7 @@ import Autocomplete from '@mui/material/Autocomplete';
 import { Chip, TextField } from '@mui/material';
 import { SearchTarget } from '../../lib/search-target';
 import { Tag } from '../../lib/tagged-character';
+import { AutocompleteOption } from '../../lib/autocomplete';
 
 interface Props {
   /**
@@ -29,7 +30,7 @@ interface Props {
   /**
    * 検索ワードの補完候補
    */
-  autocompleteOptions: Tag[] | string[];
+  autocompleteOptions: AutocompleteOption[];
   /**
    * テーマ関係のスタイル指定
    */
@@ -44,9 +45,11 @@ export const SearchForm: React.FC<Props> = ({
   autocompleteOptions,
   sx,
 }) => {
-  const onTextChange = (_, texts: (string | Tag)[]) => {
-    onChangeTexts(texts.map((text) => typeof text === 'string' ? text : text.label));
-  }
+  const onTextChange = (_, texts: (string | AutocompleteOption)[]) => {
+    onChangeTexts(
+      texts.map((text) => (typeof text === 'string' ? text : text.label))
+    );
+  };
   const theme = useTheme();
   const placeholder = `${target === SearchTarget.TAG ? 'タグ' : '名前'}を入力`;
 
@@ -68,12 +71,8 @@ export const SearchForm: React.FC<Props> = ({
             ? (option: Tag) => option.category
             : undefined
         }
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore valueの要求型が明らかにおかしいから一時的にignoreする
-        isOptionEqualToValue={
-          target === SearchTarget.TAG
-            ? (option: Tag, value: string) => option.label === value
-            : undefined
+        isOptionEqualToValue={(option: AutocompleteOption, value: string) =>
+          option.label === value
         }
         fullWidth
         renderInput={(params) => (

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -5,6 +5,7 @@ import { SearchTargetSelect } from './SearchTargetSelect';
 import Autocomplete from '@mui/material/Autocomplete';
 import { Chip, TextField } from '@mui/material';
 import { SearchTarget } from '../../lib/search-target';
+import { Tag } from '../../lib/tagged-character';
 
 interface Props {
   /**
@@ -28,7 +29,7 @@ interface Props {
   /**
    * 検索ワードの補完候補
    */
-  autocompleteOptions: string[];
+  autocompleteOptions: Tag[] | string[];
   /**
    * テーマ関係のスタイル指定
    */

--- a/src/components/organisms/CharactersSearcher.stories.tsx
+++ b/src/components/organisms/CharactersSearcher.stories.tsx
@@ -22,17 +22,20 @@ Search.args = {
   characters: [
     {
       name: 'Alpha',
-      tags: ['あいうえお', 'かきくけこ'],
+      tags: [
+        { category: 'あ行', label: 'あいうえお' },
+        { category: 'か行', label: 'かきくけこ' },
+      ],
       showDefault: true,
     },
     {
       name: 'Beta',
-      tags: ['かきくけこ'],
+      tags: [{ category: 'か行', label: 'かきくけこ' }],
       showDefault: true,
     },
     {
       name: 'Gamma',
-      tags: ['さしすせそ'],
+      tags: [{ category: 'さ行', label: 'さしすせそ' }],
       showDefault: false,
     },
   ],

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -2,7 +2,7 @@ import { Grid, SxProps, Theme } from '@mui/material';
 import React from 'react';
 import {
   filterCharactersByNameWords,
-  filterCharactersByTags,
+  filterCharactersByTagLabels,
   TaggedCharacter,
 } from '../../lib/tagged-character';
 import { CharacterCard } from '../molecules/CharacterCard';
@@ -30,7 +30,7 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
   const search = (target: SearchTarget, texts: string[], showAll: boolean) => {
     const searchResults =
       target === SearchTarget.TAG
-        ? filterCharactersByTags(characters, texts, showAll)
+        ? filterCharactersByTagLabels(characters, texts, showAll)
         : filterCharactersByNameWords(characters, texts, showAll);
     setSearchResults(searchResults);
   };
@@ -52,10 +52,10 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
     setShowAll(showAll);
     search(searchTarget, searchTexts, showAll);
   };
-  const onClickTag = (tag: string) => {
-    setSearchTexts([tag]);
+  const onClickTag = (tagLabel: string) => {
+    setSearchTexts([tagLabel]);
     setSearchTarget(SearchTarget.TAG);
-    search(SearchTarget.TAG, [tag], showAll);
+    search(SearchTarget.TAG, [tagLabel], showAll);
   };
 
   const autocompleteOptions = generateAutocompleteOptions(
@@ -83,7 +83,11 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
       <Grid container spacing={2} sx={{ mt: 1 }}>
         {searchResults.map(({ name, tags }) => (
           <Grid item key={name} xs={12} sm={6} md={4}>
-            <CharacterCard name={name} tags={tags} onClickTag={onClickTag} />
+            <CharacterCard
+              name={name}
+              tagLabels={tags.map(({ label }) => label)}
+              onClickTag={onClickTag}
+            />
           </Grid>
         ))}
       </Grid>

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -79,7 +79,7 @@ describe('generateAutocompleteOptions', () => {
       it('名前の一覧を返す', () => {
         expect(
           generateAutocompleteOptions(characters, SearchTarget.NAME, true)
-        ).toEqual(['Alpha', 'Beta', 'Gamma']);
+        ).toEqual([{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }]);
       });
     });
   });
@@ -100,7 +100,7 @@ describe('generateAutocompleteOptions', () => {
       it('デフォルト表示キャラの名前の一覧を返す', () => {
         expect(
           generateAutocompleteOptions(characters, SearchTarget.NAME, false)
-        ).toEqual(['Alpha', 'Beta']);
+        ).toEqual([{ label: 'Alpha' }, { label: 'Beta' }]);
       });
     });
   });

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -1,22 +1,63 @@
-import { generateAutocompleteOptions } from './autocomplete';
+import { generateAutocompleteOptions, uniqueTags } from './autocomplete';
 import { SearchTarget } from './search-target';
-import { TaggedCharacter } from './tagged-character';
+import { Tag, TaggedCharacter } from './tagged-character';
+
+describe('uniqueTags', () => {
+  const tags: Tag[] = [
+    {
+      category: 'alpha',
+      label: 'あるは',
+    },
+    {
+      category: 'alpha',
+      label: 'あるふあ',
+    },
+    {
+      category: 'alpha',
+      label: 'あるは',
+    },
+    {
+      category: 'beta',
+      label: 'べた',
+    },
+  ];
+
+  it('重複を除いたタグの一覧が返る', () => {
+    expect(uniqueTags(tags)).toEqual([
+      {
+        category: 'alpha',
+        label: 'あるは',
+      },
+      {
+        category: 'alpha',
+        label: 'あるふあ',
+      },
+      {
+        category: 'beta',
+        label: 'べた',
+      },
+    ]);
+  });
+});
 
 describe('generateAutocompleteOptions', () => {
   const characters: TaggedCharacter[] = [
     {
       name: 'Alpha',
-      tags: ['x-ray', 'yankee'],
+      tags: [
+        { category: 'X', label: 'x-ray' },
+        { category: 'Y', label: 'yankee' },
+      ],
       showDefault: true,
     },
     {
       name: 'Beta',
-      tags: ['x-ray'],
+      tags: [{ category: 'X', label: 'x-ray' }],
       showDefault: true,
     },
     {
       name: 'Gamma',
-      tags: ['zulu'],
+      tags: [{ category: 'Z', label: 'zulu' }],
       showDefault: false,
     },
   ];
@@ -26,7 +67,11 @@ describe('generateAutocompleteOptions', () => {
       it('タグの一覧を重複なく返す', () => {
         expect(
           generateAutocompleteOptions(characters, SearchTarget.TAG, true)
-        ).toEqual(['x-ray', 'yankee', 'zulu']);
+        ).toEqual([
+          { category: 'X', label: 'x-ray' },
+          { category: 'Y', label: 'yankee' },
+          { category: 'Z', label: 'zulu' },
+        ]);
       });
     });
 
@@ -44,7 +89,10 @@ describe('generateAutocompleteOptions', () => {
       it('デフォルト表示キャラのタグの一覧を重複なく返す', () => {
         expect(
           generateAutocompleteOptions(characters, SearchTarget.TAG, false)
-        ).toEqual(['x-ray', 'yankee']);
+        ).toEqual([
+          { category: 'X', label: 'x-ray' },
+          { category: 'Y', label: 'yankee' },
+        ]);
       });
     });
 

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -1,12 +1,16 @@
-import { generateAutocompleteOptions, uniqueTags } from './autocomplete';
+import { generateAutocompleteOptions, uniqueAndSortTags } from './autocomplete';
 import { SearchTarget } from './search-target';
 import { Tag, TaggedCharacter } from './tagged-character';
 
-describe('uniqueTags', () => {
+describe('uniqueAndSortTags', () => {
   const tags: Tag[] = [
     {
       category: 'alpha',
       label: 'あるは',
+    },
+    {
+      category: 'beta',
+      label: 'べた',
     },
     {
       category: 'alpha',
@@ -16,14 +20,10 @@ describe('uniqueTags', () => {
       category: 'alpha',
       label: 'あるは',
     },
-    {
-      category: 'beta',
-      label: 'べた',
-    },
   ];
 
-  it('重複を除いたタグの一覧が返る', () => {
-    expect(uniqueTags(tags)).toEqual([
+  it('重複を除き文字コード順にソートしたタグの一覧が返る', () => {
+    expect(uniqueAndSortTags(tags)).toEqual([
       {
         category: 'alpha',
         label: 'あるは',

--- a/src/lib/autocomplete.spec.ts
+++ b/src/lib/autocomplete.spec.ts
@@ -48,7 +48,7 @@ describe('generateAutocompleteOptions', () => {
       });
     });
 
-    describe('検索対象がタグの場合', () => {
+    describe('検索対象が名前の場合', () => {
       it('デフォルト表示キャラの名前の一覧を返す', () => {
         expect(
           generateAutocompleteOptions(characters, SearchTarget.NAME, false)

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -1,6 +1,12 @@
 import { Tag, TaggedCharacter } from './tagged-character';
 import { SearchTarget } from './search-target';
 
+export interface CharacterName {
+  label: string;
+}
+
+export type AutocompleteOption = Tag | CharacterName;
+
 export const uniqueAndSortTags = (tags: Tag[]): Tag[] => {
   return tags
     .filter(
@@ -17,7 +23,7 @@ export const generateAutocompleteOptions = (
   characters: TaggedCharacter[],
   target: SearchTarget,
   showAll: boolean
-): Tag[] | string[] => {
+): AutocompleteOption[] => {
   const charactersShown = characters.filter(
     ({ showDefault }) => showAll || showDefault
   );
@@ -25,6 +31,6 @@ export const generateAutocompleteOptions = (
     case SearchTarget.TAG:
       return uniqueAndSortTags(charactersShown.flatMap(({ tags }) => tags));
     case SearchTarget.NAME:
-      return charactersShown.map(({ name }) => name);
+      return charactersShown.map(({ name }) => ({ label: name }));
   }
 };

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -1,6 +1,16 @@
 import { Tag, TaggedCharacter } from './tagged-character';
 import { SearchTarget } from './search-target';
 
+export const uniqueTags = (tags: Tag[]): Tag[] => {
+  return tags.filter(
+    (tag, index) =>
+      tags.findIndex(
+        ({ category, label }) =>
+          tag.category === category && tag.label === label
+      ) === index
+  );
+};
+
 export const generateAutocompleteOptions = (
   characters: TaggedCharacter[],
   target: SearchTarget,
@@ -11,7 +21,7 @@ export const generateAutocompleteOptions = (
   );
   switch (target) {
     case SearchTarget.TAG:
-      return Array.from(new Set(charactersShown.flatMap(({ tags }) => tags)));
+      return uniqueTags(charactersShown.flatMap(({ tags }) => tags));
     case SearchTarget.NAME:
       return charactersShown.map(({ name }) => name);
   }

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -2,13 +2,15 @@ import { Tag, TaggedCharacter } from './tagged-character';
 import { SearchTarget } from './search-target';
 
 export const uniqueAndSortTags = (tags: Tag[]): Tag[] => {
-  return tags.filter(
-    (tag, index) =>
-      tags.findIndex(
-        ({ category, label }) =>
-          tag.category === category && tag.label === label
-      ) === index
-  ).sort((a, b) => a.category.localeCompare(b.category));
+  return tags
+    .filter(
+      (tag, index) =>
+        tags.findIndex(
+          ({ category, label }) =>
+            tag.category === category && tag.label === label
+        ) === index
+    )
+    .sort((a, b) => a.category.localeCompare(b.category));
 };
 
 export const generateAutocompleteOptions = (

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -1,14 +1,14 @@
 import { Tag, TaggedCharacter } from './tagged-character';
 import { SearchTarget } from './search-target';
 
-export const uniqueTags = (tags: Tag[]): Tag[] => {
+export const uniqueAndSortTags = (tags: Tag[]): Tag[] => {
   return tags.filter(
     (tag, index) =>
       tags.findIndex(
         ({ category, label }) =>
           tag.category === category && tag.label === label
       ) === index
-  );
+  ).sort((a, b) => a.category.localeCompare(b.category));
 };
 
 export const generateAutocompleteOptions = (
@@ -21,7 +21,7 @@ export const generateAutocompleteOptions = (
   );
   switch (target) {
     case SearchTarget.TAG:
-      return uniqueTags(charactersShown.flatMap(({ tags }) => tags));
+      return uniqueAndSortTags(charactersShown.flatMap(({ tags }) => tags));
     case SearchTarget.NAME:
       return charactersShown.map(({ name }) => name);
   }

--- a/src/lib/autocomplete.ts
+++ b/src/lib/autocomplete.ts
@@ -1,23 +1,18 @@
-import { TaggedCharacter } from './tagged-character';
+import { Tag, TaggedCharacter } from './tagged-character';
 import { SearchTarget } from './search-target';
 
 export const generateAutocompleteOptions = (
   characters: TaggedCharacter[],
   target: SearchTarget,
   showAll: boolean
-): string[] => {
+): Tag[] | string[] => {
+  const charactersShown = characters.filter(
+    ({ showDefault }) => showAll || showDefault
+  );
   switch (target) {
     case SearchTarget.TAG:
-      return Array.from(
-        new Set(
-          characters.flatMap(({ tags, showDefault }) =>
-            showAll || showDefault ? tags : []
-          )
-        )
-      );
+      return Array.from(new Set(charactersShown.flatMap(({ tags }) => tags)));
     case SearchTarget.NAME:
-      return characters.flatMap(({ name, showDefault }) =>
-        showAll || showDefault ? name : []
-      );
+      return charactersShown.map(({ name }) => name);
   }
 };

--- a/src/lib/load-data.spec.ts
+++ b/src/lib/load-data.spec.ts
@@ -11,7 +11,7 @@ describe('isTag', () => {
     it('trueが返る', () => {
       const obj = {
         category: 'category',
-        name: 'name',
+        label: 'label',
       };
       expect(isTag(obj)).toBeTruthy();
     });
@@ -21,17 +21,17 @@ describe('isTag', () => {
     it('falseが返る', () => {
       const obj = {
         category: 5,
-        name: 'name',
+        label: 'label',
       };
       expect(isTag(obj)).toBeFalsy();
     });
   });
 
-  describe('nameが文字列でない場合', () => {
+  describe('labelが文字列でない場合', () => {
     it('falseが返る', () => {
       const obj = {
         category: 'category',
-        name: null,
+        label: null,
       };
       expect(isTag(obj)).toBeFalsy();
     });
@@ -44,8 +44,8 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 'Name',
         tags: [
-          { category: 'alpha', name: 'test1' },
-          { category: 'beta', name: 'test2' },
+          { category: 'alpha', label: 'test1' },
+          { category: 'beta', label: 'test2' },
         ],
         showDefault: false,
       };
@@ -58,8 +58,8 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 1,
         tags: [
-          { category: 'alpha', name: 'test1' },
-          { category: 'beta', name: 'test2' },
+          { category: 'alpha', label: 'test1' },
+          { category: 'beta', label: 'test2' },
         ],
         showDefault: true,
       };
@@ -82,7 +82,7 @@ describe('isTaggedCharacter', () => {
     it('falseが返る', () => {
       const obj = {
         name: 'Name',
-        tags: [{ category: 'alpha', name: 'test1' }, {}],
+        tags: [{ category: 'alpha', label: 'test1' }, {}],
         showDefault: false,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
@@ -94,8 +94,8 @@ describe('isTaggedCharacter', () => {
       const obj = {
         name: 'Name',
         tags: [
-          { category: 'alpha', name: 'test1' },
-          { category: 'beta', name: 'test2' },
+          { category: 'alpha', label: 'test1' },
+          { category: 'beta', label: 'test2' },
         ],
         showDefault: 1,
       };
@@ -110,8 +110,8 @@ describe('loadCharactersDataFromJson', () => {
       {
         name: 'Alpha',
         tags: [
-          { category: 'number', name: 'one' },
-          { category: 'count', name: 'two' },
+          { category: 'number', label: 'one' },
+          { category: 'count', label: 'two' },
         ],
         showDefault: true,
       },
@@ -132,14 +132,14 @@ describe('loadCharactersDataFromJson', () => {
       {
         name: 1,
         tags: [
-          { category: 'number', name: 'one' },
-          { category: 'count', name: 'two' },
+          { category: 'number', label: 'one' },
+          { category: 'count', label: 'two' },
         ],
         showDefault: true,
       },
       {
         name: 'Beta',
-        tags: [{ category: 'number', name: 'three' }],
+        tags: [{ category: 'number', label: 'three' }],
         showDefault: true,
       },
     ];

--- a/src/lib/load-data.spec.ts
+++ b/src/lib/load-data.spec.ts
@@ -1,16 +1,52 @@
 import {
+  isTag,
   isTaggedCharacter,
   loadCharactersDataFromJson,
   loadSampleCharactersData,
 } from './load-data';
 import charactersData from '../../sample/characters-data/sample.json';
 
+describe('isTag', () => {
+  describe('データ形式が正しい場合', () => {
+    it('trueが返る', () => {
+      const obj = {
+        category: 'category',
+        name: 'name',
+      };
+      expect(isTag(obj)).toBeTruthy();
+    });
+  });
+
+  describe('categoryが文字列でない場合', () => {
+    it('falseが返る', () => {
+      const obj = {
+        category: 5,
+        name: 'name',
+      };
+      expect(isTag(obj)).toBeFalsy();
+    });
+  });
+
+  describe('nameが文字列でない場合', () => {
+    it('falseが返る', () => {
+      const obj = {
+        category: 'category',
+        name: null,
+      };
+      expect(isTag(obj)).toBeFalsy();
+    });
+  });
+});
+
 describe('isTaggedCharacter', () => {
   describe('データ形式が正しい場合', () => {
     it('trueが返る', () => {
       const obj = {
         name: 'Name',
-        tags: ['test1', 'test2'],
+        tags: [
+          { category: 'alpha', name: 'test1' },
+          { category: 'beta', name: 'test2' },
+        ],
         showDefault: false,
       };
       expect(isTaggedCharacter(obj)).toBeTruthy();
@@ -21,7 +57,10 @@ describe('isTaggedCharacter', () => {
     it('falseが返る', () => {
       const obj = {
         name: 1,
-        tags: ['test1', 'test2'],
+        tags: [
+          { category: 'alpha', name: 'test1' },
+          { category: 'beta', name: 'test2' },
+        ],
         showDefault: true,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
@@ -39,11 +78,11 @@ describe('isTaggedCharacter', () => {
     });
   });
 
-  describe('tagsが配列かつ文字列でない要素を含む場合', () => {
+  describe('tagsが配列かつTagでないオブジェクトを含む場合', () => {
     it('falseが返る', () => {
       const obj = {
         name: 'Name',
-        tags: ['test1', 2],
+        tags: [{ category: 'alpha', name: 'test1' }, {}],
         showDefault: false,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
@@ -54,7 +93,10 @@ describe('isTaggedCharacter', () => {
     it('falseが返る', () => {
       const obj = {
         name: 'Name',
-        tags: ['test1', 'test2'],
+        tags: [
+          { category: 'alpha', name: 'test1' },
+          { category: 'beta', name: 'test2' },
+        ],
         showDefault: 1,
       };
       expect(isTaggedCharacter(obj)).toBeFalsy();
@@ -67,7 +109,10 @@ describe('loadCharactersDataFromJson', () => {
     const json = [
       {
         name: 'Alpha',
-        tags: ['one', 'two'],
+        tags: [
+          { category: 'number', name: 'one' },
+          { category: 'count', name: 'two' },
+        ],
         showDefault: true,
       },
       {
@@ -86,12 +131,15 @@ describe('loadCharactersDataFromJson', () => {
     const json = [
       {
         name: 1,
-        tags: ['one, two'],
+        tags: [
+          { category: 'number', name: 'one' },
+          { category: 'count', name: 'two' },
+        ],
         showDefault: true,
       },
       {
         name: 'Beta',
-        tags: ['three'],
+        tags: [{ category: 'number', name: 'three' }],
         showDefault: true,
       },
     ];

--- a/src/lib/load-data.ts
+++ b/src/lib/load-data.ts
@@ -1,7 +1,12 @@
 import sampleCharacterData from '../../sample/characters-data/sample.json';
-import { TaggedCharacter } from './tagged-character';
+import { Tag, TaggedCharacter } from './tagged-character';
 
 type WouldBeTaggedCharacter = { [K in keyof TaggedCharacter]?: unknown };
+type WouldBeTag = { [K in keyof Tag]?: unknown };
+
+export const isTag = (obj: WouldBeTag): obj is Tag => {
+  return typeof obj.category === 'string' && typeof obj.name === 'string';
+};
 
 export const isTaggedCharacter = (
   obj: WouldBeTaggedCharacter
@@ -9,7 +14,7 @@ export const isTaggedCharacter = (
   return (
     typeof obj.name === 'string' &&
     Array.isArray(obj.tags) &&
-    obj.tags.every((tag) => typeof tag === 'string') &&
+    obj.tags.every(isTag) &&
     typeof obj.showDefault === 'boolean'
   );
 };

--- a/src/lib/load-data.ts
+++ b/src/lib/load-data.ts
@@ -5,7 +5,7 @@ type WouldBeTaggedCharacter = { [K in keyof TaggedCharacter]?: unknown };
 type WouldBeTag = { [K in keyof Tag]?: unknown };
 
 export const isTag = (obj: WouldBeTag): obj is Tag => {
-  return typeof obj.category === 'string' && typeof obj.name === 'string';
+  return typeof obj.category === 'string' && typeof obj.label === 'string';
 };
 
 export const isTaggedCharacter = (

--- a/src/lib/tagged-character.spec.ts
+++ b/src/lib/tagged-character.spec.ts
@@ -8,7 +8,7 @@ describe('filterCharactersByTagNames', () => {
   const testTag1 = 'aurum';
   const testTag2 = 'borium';
   const alpha: TaggedCharacter = {
-    name: 'alpha',
+    name: '',
     tags: [
       { category: '', name: testTag1 },
       { category: '', name: 'other-tag' },
@@ -17,7 +17,7 @@ describe('filterCharactersByTagNames', () => {
     showDefault: true,
   };
   const beta: TaggedCharacter = {
-    name: 'beta',
+    name: '',
     tags: [
       { category: '', name: 'other-tag' },
       { category: '', name: testTag1 },
@@ -25,7 +25,7 @@ describe('filterCharactersByTagNames', () => {
     showDefault: true,
   };
   const gamma: TaggedCharacter = {
-    name: 'gamma',
+    name: '',
     tags: [
       { category: '', name: testTag1 },
       { category: '', name: testTag2 },
@@ -33,7 +33,7 @@ describe('filterCharactersByTagNames', () => {
     showDefault: false,
   };
   const delta: TaggedCharacter = {
-    name: 'delta',
+    name: '',
     tags: [{ category: '', name: 'other-tag' }],
     showDefault: true,
   };

--- a/src/lib/tagged-character.spec.ts
+++ b/src/lib/tagged-character.spec.ts
@@ -1,40 +1,40 @@
 import {
-  filterCharactersByTagNames,
+  filterCharactersByTagLabels,
   TaggedCharacter,
   filterCharactersByNameWords,
 } from './tagged-character';
 
-describe('filterCharactersByTagNames', () => {
+describe('filterCharactersByTagLabels', () => {
   const testTag1 = 'aurum';
   const testTag2 = 'borium';
   const alpha: TaggedCharacter = {
     name: '',
     tags: [
-      { category: '', name: testTag1 },
-      { category: '', name: 'other-tag' },
-      { category: '', name: testTag2 },
+      { category: '', label: testTag1 },
+      { category: '', label: 'other-tag' },
+      { category: '', label: testTag2 },
     ],
     showDefault: true,
   };
   const beta: TaggedCharacter = {
     name: '',
     tags: [
-      { category: '', name: 'other-tag' },
-      { category: '', name: testTag1 },
+      { category: '', label: 'other-tag' },
+      { category: '', label: testTag1 },
     ],
     showDefault: true,
   };
   const gamma: TaggedCharacter = {
     name: '',
     tags: [
-      { category: '', name: testTag1 },
-      { category: '', name: testTag2 },
+      { category: '', label: testTag1 },
+      { category: '', label: testTag2 },
     ],
     showDefault: false,
   };
   const delta: TaggedCharacter = {
     name: '',
-    tags: [{ category: '', name: 'other-tag' }],
+    tags: [{ category: '', label: 'other-tag' }],
     showDefault: true,
   };
   const characters = [alpha, beta, gamma, delta];
@@ -43,7 +43,7 @@ describe('filterCharactersByTagNames', () => {
     describe('指定タグが1つの場合', () => {
       it('指定タグを持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTagNames(characters, [testTag1], true)
+          filterCharactersByTagLabels(characters, [testTag1], true)
         ).toStrictEqual([alpha, beta, gamma]);
       });
     });
@@ -51,7 +51,7 @@ describe('filterCharactersByTagNames', () => {
     describe('指定タグが複数の場合', () => {
       it('指定タグを全て持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTagNames(characters, [testTag1, testTag2], true)
+          filterCharactersByTagLabels(characters, [testTag1, testTag2], true)
         ).toStrictEqual([alpha, gamma]);
       });
     });
@@ -59,14 +59,14 @@ describe('filterCharactersByTagNames', () => {
     describe('指定したタグを持つキャラクターがいない場合', () => {
       it('空配列が返る', () => {
         expect(
-          filterCharactersByTagNames(characters, ['not-set-tag'], true)
+          filterCharactersByTagLabels(characters, ['not-set-tag'], true)
         ).toStrictEqual([]);
       });
     });
 
     describe('タグ指定がない場合', () => {
       it('元の配列が返る', () => {
-        expect(filterCharactersByTagNames(characters, [], true)).toStrictEqual(
+        expect(filterCharactersByTagLabels(characters, [], true)).toStrictEqual(
           characters
         );
       });
@@ -77,7 +77,7 @@ describe('filterCharactersByTagNames', () => {
     describe('指定タグが1つの場合', () => {
       it('デフォルト表示され指定タグを全て持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTagNames(characters, [testTag1], false)
+          filterCharactersByTagLabels(characters, [testTag1], false)
         ).toStrictEqual([alpha, beta]);
       });
     });
@@ -85,7 +85,7 @@ describe('filterCharactersByTagNames', () => {
     describe('指定タグが複数の場合', () => {
       it('デフォルト表示され指定タグを全て持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTagNames(characters, [testTag1, testTag2], false)
+          filterCharactersByTagLabels(characters, [testTag1, testTag2], false)
         ).toStrictEqual([alpha]);
       });
     });
@@ -93,16 +93,16 @@ describe('filterCharactersByTagNames', () => {
     describe('指定したタグを持つキャラクターがいない場合', () => {
       it('空配列が返る', () => {
         expect(
-          filterCharactersByTagNames(characters, ['not-set-tag'], true)
+          filterCharactersByTagLabels(characters, ['not-set-tag'], true)
         ).toStrictEqual([]);
       });
     });
 
     describe('タグ指定がない場合', () => {
       it('デフォルト表示されるキャラクターの配列が返る', () => {
-        expect(filterCharactersByTagNames(characters, [], false)).toStrictEqual(
-          [alpha, beta, delta]
-        );
+        expect(
+          filterCharactersByTagLabels(characters, [], false)
+        ).toStrictEqual([alpha, beta, delta]);
       });
     });
   });

--- a/src/lib/tagged-character.spec.ts
+++ b/src/lib/tagged-character.spec.ts
@@ -1,30 +1,40 @@
 import {
-  filterCharactersByTags,
+  filterCharactersByTagNames,
   TaggedCharacter,
   filterCharactersByNameWords,
 } from './tagged-character';
 
-describe('filterCharactersByTag', () => {
+describe('filterCharactersByTagNames', () => {
   const testTag1 = 'aurum';
   const testTag2 = 'borium';
   const alpha: TaggedCharacter = {
     name: 'alpha',
-    tags: [testTag1, 'other-tag', testTag2],
+    tags: [
+      { category: '', name: testTag1 },
+      { category: '', name: 'other-tag' },
+      { category: '', name: testTag2 },
+    ],
     showDefault: true,
   };
   const beta: TaggedCharacter = {
     name: 'beta',
-    tags: ['other-tag', testTag1],
+    tags: [
+      { category: '', name: 'other-tag' },
+      { category: '', name: testTag1 },
+    ],
     showDefault: true,
   };
   const gamma: TaggedCharacter = {
     name: 'gamma',
-    tags: [testTag1, testTag2],
+    tags: [
+      { category: '', name: testTag1 },
+      { category: '', name: testTag2 },
+    ],
     showDefault: false,
   };
   const delta: TaggedCharacter = {
     name: 'delta',
-    tags: ['other-tag'],
+    tags: [{ category: '', name: 'other-tag' }],
     showDefault: true,
   };
   const characters = [alpha, beta, gamma, delta];
@@ -33,7 +43,7 @@ describe('filterCharactersByTag', () => {
     describe('指定タグが1つの場合', () => {
       it('指定タグを持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTags(characters, [testTag1], true)
+          filterCharactersByTagNames(characters, [testTag1], true)
         ).toStrictEqual([alpha, beta, gamma]);
       });
     });
@@ -41,7 +51,7 @@ describe('filterCharactersByTag', () => {
     describe('指定タグが複数の場合', () => {
       it('指定タグを全て持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTags(characters, [testTag1, testTag2], true)
+          filterCharactersByTagNames(characters, [testTag1, testTag2], true)
         ).toStrictEqual([alpha, gamma]);
       });
     });
@@ -49,14 +59,14 @@ describe('filterCharactersByTag', () => {
     describe('指定したタグを持つキャラクターがいない場合', () => {
       it('空配列が返る', () => {
         expect(
-          filterCharactersByTags(characters, ['not-set-tag'], true)
+          filterCharactersByTagNames(characters, ['not-set-tag'], true)
         ).toStrictEqual([]);
       });
     });
 
     describe('タグ指定がない場合', () => {
       it('元の配列が返る', () => {
-        expect(filterCharactersByTags(characters, [], true)).toStrictEqual(
+        expect(filterCharactersByTagNames(characters, [], true)).toStrictEqual(
           characters
         );
       });
@@ -67,7 +77,7 @@ describe('filterCharactersByTag', () => {
     describe('指定タグが1つの場合', () => {
       it('デフォルト表示され指定タグを全て持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTags(characters, [testTag1], false)
+          filterCharactersByTagNames(characters, [testTag1], false)
         ).toStrictEqual([alpha, beta]);
       });
     });
@@ -75,7 +85,7 @@ describe('filterCharactersByTag', () => {
     describe('指定タグが複数の場合', () => {
       it('デフォルト表示され指定タグを全て持つキャラクターの配列が返る', () => {
         expect(
-          filterCharactersByTags(characters, [testTag1, testTag2], false)
+          filterCharactersByTagNames(characters, [testTag1, testTag2], false)
         ).toStrictEqual([alpha]);
       });
     });
@@ -83,18 +93,16 @@ describe('filterCharactersByTag', () => {
     describe('指定したタグを持つキャラクターがいない場合', () => {
       it('空配列が返る', () => {
         expect(
-          filterCharactersByTags(characters, ['not-set-tag'], true)
+          filterCharactersByTagNames(characters, ['not-set-tag'], true)
         ).toStrictEqual([]);
       });
     });
 
     describe('タグ指定がない場合', () => {
       it('デフォルト表示されるキャラクターの配列が返る', () => {
-        expect(filterCharactersByTags(characters, [], false)).toStrictEqual([
-          alpha,
-          beta,
-          delta,
-        ]);
+        expect(filterCharactersByTagNames(characters, [], false)).toStrictEqual(
+          [alpha, beta, delta]
+        );
       });
     });
   });

--- a/src/lib/tagged-character.ts
+++ b/src/lib/tagged-character.ts
@@ -1,4 +1,7 @@
-export type Tag = string;
+export interface Tag {
+  category: string;
+  name: string;
+}
 
 export interface TaggedCharacter {
   name: string;
@@ -6,15 +9,16 @@ export interface TaggedCharacter {
   showDefault: boolean;
 }
 
-export const filterCharactersByTags = (
+export const filterCharactersByTagNames = (
   characters: TaggedCharacter[],
-  tags: Tag[],
+  tagNames: string[],
   showAll: boolean
 ): TaggedCharacter[] => {
   return characters.filter((character) => {
+    const characterTagNames = character.tags.map(({ name }) => name);
     return (
       (showAll || character.showDefault) &&
-      tags.every((tag) => character.tags.includes(tag))
+      tagNames.every((tagName) => characterTagNames.includes(tagName))
     );
   });
 };

--- a/src/lib/tagged-character.ts
+++ b/src/lib/tagged-character.ts
@@ -1,6 +1,6 @@
 export interface Tag {
   category: string;
-  name: string;
+  label: string;
 }
 
 export interface TaggedCharacter {
@@ -9,16 +9,16 @@ export interface TaggedCharacter {
   showDefault: boolean;
 }
 
-export const filterCharactersByTagNames = (
+export const filterCharactersByTagLabels = (
   characters: TaggedCharacter[],
-  tagNames: string[],
+  tagLabels: string[],
   showAll: boolean
 ): TaggedCharacter[] => {
   return characters.filter((character) => {
-    const characterTagNames = character.tags.map(({ name }) => name);
+    const characterTagLabels = character.tags.map(({ label }) => label);
     return (
       (showAll || character.showDefault) &&
-      tagNames.every((tagName) => characterTagNames.includes(tagName))
+      tagLabels.every((tagLabel) => characterTagLabels.includes(tagLabel))
     );
   });
 };


### PR DESCRIPTION
Resolve #34 

- タグをカテゴリとラベルを持ったobjectにする
    - サンプルデータおよびテスト用データにもカテゴリをもたせる
- 補完候補ではカテゴリでグルーピングし、選択時はラベルのみ渡す
    - `value` を `string[]` にするため
- 補完候補はラベルを持ったobjectとして生成する
    - 名前とタグで補完候補の型が違うと一致判定がやりにくいため、双方の共通プロパティとしてラベルを使う
- おまけ: `SearchForm` の型エラーがなくなったためエラー抑制コメントを削除