### PR TITLE
コンポーネントのパターンに合わせてStoryを準備する

### DIFF
--- a/src/components/molecules/SearchCondition.stories.tsx
+++ b/src/components/molecules/SearchCondition.stories.tsx
@@ -29,10 +29,34 @@ const Template: ComponentStory<typeof SearchCondition> = (args) => (
   <SearchCondition {...args} />
 );
 
-export const Condition = Template.bind({});
-Condition.args = {
+export const SearchByTag = Template.bind({});
+SearchByTag.args = {
   target: SearchTarget.TAG,
   texts: ['あいうえお'],
+  showAll: false,
+  sx: {},
+};
+
+export const SearchByName = Template.bind({});
+SearchByName.args = {
+  target: SearchTarget.NAME,
+  texts: ['かきくけこ'],
+  showAll: false,
+  sx: {},
+};
+
+export const ShowAll = Template.bind({});
+ShowAll.args = {
+  target: SearchTarget.TAG,
+  texts: ['さしすせそ'],
+  showAll: true,
+  sx: {},
+};
+
+export const NotSearched = Template.bind({});
+NotSearched.args = {
+  target: SearchTarget.TAG,
+  texts: [],
   showAll: false,
   sx: {},
 };

--- a/src/components/molecules/SearchForm.stories.tsx
+++ b/src/components/molecules/SearchForm.stories.tsx
@@ -29,13 +29,35 @@ const Template: ComponentStory<typeof SearchForm> = (args) => (
   <SearchForm {...args} />
 );
 
-export const Search = Template.bind({});
-Search.args = {
+export const SearchByTag = Template.bind({});
+SearchByTag.args = {
   target: SearchTarget.TAG,
   texts: [],
   autocompleteOptions: [
     { category: 'あ行', label: 'あいうえお' },
     { category: 'か行', label: 'かきくけこ' },
+  ],
+  sx: {},
+};
+
+export const SearchByName = Template.bind({});
+SearchByName.args = {
+  target: SearchTarget.NAME,
+  texts: [],
+  autocompleteOptions: [
+    { category: 'さ行', label: 'さしすせそ' },
+    { category: 'た行', label: 'たちつてと' },
+  ],
+  sx: {},
+};
+
+export const InputtedWords = Template.bind({});
+InputtedWords.args = {
+  target: SearchTarget.TAG,
+  texts: ['あいうえお', 'なにぬねの'],
+  autocompleteOptions: [
+    { category: 'な行', label: 'なにぬねの' },
+    { category: 'は行', label: 'はひふへほ' },
   ],
   sx: {},
 };

--- a/src/components/molecules/SearchTargetSelect.stories.tsx
+++ b/src/components/molecules/SearchTargetSelect.stories.tsx
@@ -27,8 +27,14 @@ const Template: ComponentStory<typeof SearchTargetSelect> = (args) => (
   <SearchTargetSelect {...args} />
 );
 
-export const Select = Template.bind({});
-Select.args = {
+export const SelectTag = Template.bind({});
+SelectTag.args = {
   target: SearchTarget.TAG,
+  sx: {},
+};
+
+export const SelectName = Template.bind({});
+SelectName.args = {
+  target: SearchTarget.NAME,
   sx: {},
 };


### PR DESCRIPTION
Resolve #48 

- propsで文言やデザインを出し分けているコンポーネントは各パターンごとにstoryを作る
    - controlsだけに頼らない