### PR TITLE
元データのフェッチ時クエリをつけない

### DIFF
--- a/src/pages/api/characters-data/[name].ts
+++ b/src/pages/api/characters-data/[name].ts
@@ -8,7 +8,8 @@ const handler: NextApiHandler = async (request, response) => {
   const fetchResult = await fetch(
     `${process.env.CHARACTERS_DATA_STORAGE_URL}/${name}.json`
   );
-  if (fetchResult.status === 404) {
+  const { status } = fetchResult;
+  if (400 <= status && status < 500) {
     return response.status(404).json({ error: 'Not Found' });
   }
   const json = await fetchResult.json();

--- a/src/pages/api/characters-data/[name].ts
+++ b/src/pages/api/characters-data/[name].ts
@@ -6,7 +6,7 @@ const handler: NextApiHandler = async (request, response) => {
     return response.status(400).json({ error: 'Name must be string' });
   }
   const fetchResult = await fetch(
-    `${process.env.CHARACTERS_DATA_STORAGE_URL}/${name}.json?alt=media`
+    `${process.env.CHARACTERS_DATA_STORAGE_URL}/${name}.json`
   );
   if (fetchResult.status === 404) {
     return response.status(404).json({ error: 'Not Found' });


### PR DESCRIPTION
- 元データフェッチ時のクエリを外す
    - JSON置き場がfirebase storageからS3 + CloudFrontに変わった都合上必要なくなった
- 400系全体を404扱いにする
    - 存在しないpathを参照しようとするとcloufrontが403を返す
    - 必要なデータが見つからないならAPIとしてはどれも同じこと