### PR TITLE
色々メモ化して再描画の頻度を減らす

### DIFF
--- a/src/components/atoms/SearchTargetSelect.tsx
+++ b/src/components/atoms/SearchTargetSelect.tsx
@@ -25,17 +25,20 @@ export const SearchTargetSelect: React.FC<Props> = ({
   onChange,
   sx,
 }) => {
-  const onSelect = (event: SelectChangeEvent<number>) => {
-    const { value } = event.target;
-    switch (value) {
-      case SearchTarget.TAG:
-      case SearchTarget.NAME:
-        onChange(value);
-        return;
-      default:
-        throw new Error('Invalid search target');
-    }
-  };
+  const onSelect = React.useCallback(
+    (event: SelectChangeEvent<number>) => {
+      const { value } = event.target;
+      switch (value) {
+        case SearchTarget.TAG:
+        case SearchTarget.NAME:
+          onChange(value);
+          return;
+        default:
+          throw new Error('Invalid search target');
+      }
+    },
+    [onChange]
+  );
   const theme = useTheme();
 
   return (

--- a/src/components/atoms/TagBadge.tsx
+++ b/src/components/atoms/TagBadge.tsx
@@ -18,7 +18,11 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const TagBadge: React.FC<Props> = ({ children, onClick, sx }) => {
+export const TagBadge: React.FC<Props> = React.memo(function TagBadge({
+  children,
+  onClick,
+  sx,
+}) {
   const onClickButton = React.useCallback(
     () => onClick(children),
     [onClick, children]
@@ -33,4 +37,4 @@ export const TagBadge: React.FC<Props> = ({ children, onClick, sx }) => {
       {children}
     </Button>
   );
-};
+});

--- a/src/components/atoms/TagBadge.tsx
+++ b/src/components/atoms/TagBadge.tsx
@@ -18,13 +18,19 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const TagBadge: React.FC<Props> = ({ children, onClick, sx }) => (
-  <Button
-    size="small"
-    variant="outlined"
-    onClick={() => onClick(children)}
-    sx={{ textTransform: 'none', ...sx }}
-  >
-    {children}
-  </Button>
-);
+export const TagBadge: React.FC<Props> = ({ children, onClick, sx }) => {
+  const onClickButton = React.useCallback(
+    () => onClick(children),
+    [onClick, children]
+  );
+  return (
+    <Button
+      size="small"
+      variant="outlined"
+      onClick={onClickButton}
+      sx={{ textTransform: 'none', ...sx }}
+    >
+      {children}
+    </Button>
+  );
+};

--- a/src/components/molecules/CharacterCard.stories.tsx
+++ b/src/components/molecules/CharacterCard.stories.tsx
@@ -8,7 +8,7 @@ const componentMeta: ComponentMeta<typeof CharacterCard> = {
   component: CharacterCard,
   argTypes: {
     name: { control: 'text' },
-    tagLabels: { control: 'object' },
+    tags: { control: 'object' },
     sx: { control: 'object' },
   },
 };
@@ -21,13 +21,19 @@ const Template: ComponentStory<typeof CharacterCard> = (args) => (
 export const Card = Template.bind({});
 Card.args = {
   name: 'なまえ',
-  tagLabels: ['タグ1', 'タグ2'],
+  tags: [
+    { category: 'あいうえお', label: 'タグ1' },
+    { category: 'かきくけこ', label: 'タグ2' },
+  ],
   sx: {},
 };
 
 export const OverflowTags = Template.bind({});
 OverflowTags.args = {
   name: 'なまえ',
-  tagLabels: Array.from({ length: 32 }, (_, index) => `タグ${index + 1}`),
+  tags: Array.from({ length: 32 }, (_, index) => ({
+    category: `カテゴリー${index + 1}`,
+    label: `タグ${index + 1}`,
+  })),
   sx: {},
 };

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -9,6 +9,7 @@ import {
 import React from 'react';
 import { TagBadge } from '../atoms/TagBadge';
 import Stack from '@mui/material/Stack';
+import { Tag } from '../../lib/tagged-character';
 
 interface Props {
   /**
@@ -18,7 +19,7 @@ interface Props {
   /**
    * タグ一覧
    */
-  tagLabels: string[];
+  tags: Tag[];
   /**
    * タグクリック時のハンドラ
    * @param tagLabel - タグ
@@ -32,27 +33,30 @@ interface Props {
 
 export const CharacterCard: React.FC<Props> = ({
   name,
-  tagLabels,
+  tags,
   onClickTag,
   sx,
-}) => (
-  <Card elevation={2} sx={sx}>
-    <CardHeader title={name} />
-    <CardContent>
-      {/* スクロールバーがタグと被らないように下部余白を確保する */}
-      <Box pb={1} sx={{ overflowX: 'scroll' }}>
-        <Stack
-          direction="row"
-          spacing={1}
-          sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
-        >
-          {tagLabels.map((tagLabel) => (
-            <TagBadge key={tagLabel} onClick={onClickTag}>
-              {tagLabel}
-            </TagBadge>
-          ))}
-        </Stack>
-      </Box>
-    </CardContent>
-  </Card>
-);
+}) => {
+  const tagLabels = React.useMemo(() => tags.map(({ label }) => label), [tags]);
+  return (
+    <Card elevation={2} sx={sx}>
+      <CardHeader title={name} />
+      <CardContent>
+        {/* スクロールバーがタグと被らないように下部余白を確保する */}
+        <Box pb={1} sx={{ overflowX: 'scroll' }}>
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
+          >
+            {tagLabels.map((tagLabel, index) => (
+              <TagBadge key={index} onClick={onClickTag}>
+                {tagLabel}
+              </TagBadge>
+            ))}
+          </Stack>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -31,32 +31,29 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const CharacterCard: React.FC<Props> = ({
-  name,
-  tags,
-  onClickTag,
-  sx,
-}) => {
-  const tagLabels = React.useMemo(() => tags.map(({ label }) => label), [tags]);
-  return (
-    <Card elevation={2} sx={sx}>
-      <CardHeader title={name} />
-      <CardContent>
-        {/* スクロールバーがタグと被らないように下部余白を確保する */}
-        <Box pb={1} sx={{ overflowX: 'scroll' }}>
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
-          >
-            {tagLabels.map((tagLabel, index) => (
-              <TagBadge key={index} onClick={onClickTag}>
-                {tagLabel}
-              </TagBadge>
-            ))}
-          </Stack>
-        </Box>
-      </CardContent>
-    </Card>
-  );
-};
+export const CharacterCard: React.FC<Props> = React.memo(
+  function CharacterCard({ name, tags, onClickTag, sx }) {
+    const tagLabels = tags.map(({ label }) => label);
+    return (
+      <Card elevation={2} sx={sx}>
+        <CardHeader title={name} />
+        <CardContent>
+          {/* スクロールバーがタグと被らないように下部余白を確保する */}
+          <Box pb={1} sx={{ overflowX: 'scroll' }}>
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
+            >
+              {tagLabels.map((tagLabel, index) => (
+                <TagBadge key={index} onClick={onClickTag}>
+                  {tagLabel}
+                </TagBadge>
+              ))}
+            </Stack>
+          </Box>
+        </CardContent>
+      </Card>
+    );
+  }
+);

--- a/src/components/molecules/SearchCondition.tsx
+++ b/src/components/molecules/SearchCondition.tsx
@@ -41,11 +41,13 @@ export const SearchCondition: React.FC<Props> = ({
   sx,
 }) => {
   const targetStr = target === SearchTarget.TAG ? 'タグ' : '名前';
-  const onChangeCheckbox: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    onChangeShowAll(event.target.checked);
-  };
+  const onChangeCheckbox: React.ChangeEventHandler<HTMLInputElement> =
+    React.useCallback(
+      (event) => {
+        onChangeShowAll(event.target.checked);
+      },
+      [onChangeShowAll]
+    );
   const joinedText = texts.join(' ');
 
   return (

--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -45,11 +45,14 @@ export const SearchForm: React.FC<Props> = ({
   autocompleteOptions,
   sx,
 }) => {
-  const onTextChange = (_, texts: (string | AutocompleteOption)[]) => {
-    onChangeTexts(
-      texts.map((text) => (typeof text === 'string' ? text : text.label))
-    );
-  };
+  const onTextChange = React.useCallback(
+    (_, texts: (string | AutocompleteOption)[]) => {
+      onChangeTexts(
+        texts.map((text) => (typeof text === 'string' ? text : text.label))
+      );
+    },
+    [onChangeTexts]
+  );
   const theme = useTheme();
   const placeholder = `${target === SearchTarget.TAG ? 'タグ' : '名前'}を入力`;
 

--- a/src/components/organisms/CharactersList.tsx
+++ b/src/components/organisms/CharactersList.tsx
@@ -27,11 +27,7 @@ export const CharactersList: React.FC<Props> = ({
   <Grid container spacing={2} sx={sx}>
     {characters.map(({ name, tags }) => (
       <Grid item key={name} xs={12} sm={6} md={4}>
-        <CharacterCard
-          name={name}
-          tagLabels={tags.map(({ label }) => label)}
-          onClickTag={onClickTag}
-        />
+        <CharacterCard name={name} tags={tags} onClickTag={onClickTag} />
       </Grid>
     ))}
   </Grid>

--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -33,36 +33,51 @@ export const CharactersSearcher: React.FC<Props> = ({ characters, sx }) => {
     );
     setSearchResults(newSearchResults);
   }, [characters]);
-  const search = (target: SearchTarget, texts: string[], showAll: boolean) => {
-    const searchResults =
-      target === SearchTarget.TAG
-        ? filterCharactersByTagLabels(characters, texts, showAll)
-        : filterCharactersByNameWords(characters, texts, showAll);
-    setSearchResults(searchResults);
-  };
+  const search = React.useCallback(
+    (target: SearchTarget, texts: string[], showAll: boolean) => {
+      const searchResults =
+        target === SearchTarget.TAG
+          ? filterCharactersByTagLabels(characters, texts, showAll)
+          : filterCharactersByNameWords(characters, texts, showAll);
+      setSearchResults(searchResults);
+    },
+    [characters, setSearchResults]
+  );
 
   const [searchTarget, setSearchTarget] = React.useState(SearchTarget.TAG);
   const [searchTexts, setSearchTexts] = React.useState<string[]>([]);
   const [showAll, setShowAll] = React.useState(false);
 
-  const onChangeSearchTarget = (newTarget: SearchTarget) => {
-    setSearchTarget(newTarget);
-    setSearchTexts([]);
-    search(newTarget, [], showAll);
-  };
-  const onChangeSearchTexts = (newTexts: string[]) => {
-    setSearchTexts(newTexts);
-    search(searchTarget, newTexts, showAll);
-  };
-  const onChangeShowAll = (showAll: boolean) => {
-    setShowAll(showAll);
-    search(searchTarget, searchTexts, showAll);
-  };
-  const onClickTag = (tagLabel: string) => {
-    setSearchTexts([tagLabel]);
-    setSearchTarget(SearchTarget.TAG);
-    search(SearchTarget.TAG, [tagLabel], showAll);
-  };
+  const onChangeSearchTarget = React.useCallback(
+    (newTarget: SearchTarget) => {
+      setSearchTarget(newTarget);
+      setSearchTexts([]);
+      search(newTarget, [], showAll);
+    },
+    [setSearchTarget, setSearchTexts, showAll, search]
+  );
+  const onChangeSearchTexts = React.useCallback(
+    (newTexts: string[]) => {
+      setSearchTexts(newTexts);
+      search(searchTarget, newTexts, showAll);
+    },
+    [setSearchTexts, searchTarget, showAll, search]
+  );
+  const onChangeShowAll = React.useCallback(
+    (showAll: boolean) => {
+      setShowAll(showAll);
+      search(searchTarget, searchTexts, showAll);
+    },
+    [setShowAll, searchTarget, searchTexts, search]
+  );
+  const onClickTag = React.useCallback(
+    (tagLabel: string) => {
+      setSearchTexts([tagLabel]);
+      setSearchTarget(SearchTarget.TAG);
+      search(SearchTarget.TAG, [tagLabel], showAll);
+    },
+    [setSearchTarget, setSearchTexts, showAll, search]
+  );
 
   const autocompleteOptions = generateAutocompleteOptions(
     characters,


### PR DESCRIPTION
- ハンドラは基本的に `useCallback` でラップする
- 一部コンポーネントを `React.memo` でメモ化
    - `atoms/TagBadge`
    - `molecules/CharacterCard`
- `molecules/CharacterCard` をメモ化するためにpropsを一部変更
- 検索対象や検索ワードの変更のパフォーマンスが改善された
- **全キャラ表示フラグの切り替えではパフォーマンス据え置き**