### PR TITLE
useReducerを使ってfluxっぽい仕組みを作る

### DIFF
--- a/src/components/organisms/CharactersSearcher.tsx
+++ b/src/components/organisms/CharactersSearcher.tsx
@@ -1,8 +1,7 @@
 import { SxProps, Theme } from '@mui/material';
 import React from 'react';
 import {
-  filterCharactersByNameWords,
-  filterCharactersByTagLabels,
+  filterCharacters,
   TaggedCharacter,
 } from '../../lib/tagged-character';
 import { SearchForm } from '../molecules/SearchForm';
@@ -37,10 +36,7 @@ export const CharactersSearcher: React.FC<Props> = ({ charactersData, sx }) => {
   }, [characters]);
   const search = React.useCallback(
     (target: SearchTarget, texts: string[], showAll: boolean) => {
-      const searchResults =
-        target === SearchTarget.TAG
-          ? filterCharactersByTagLabels(characters, texts, showAll)
-          : filterCharactersByNameWords(characters, texts, showAll);
+      const searchResults = filterCharacters(characters, target, texts, showAll);
       setSearchResults(searchResults);
     },
     [characters, setSearchResults]

--- a/src/flux/action.ts
+++ b/src/flux/action.ts
@@ -1,0 +1,34 @@
+import { SearchTarget } from '../lib/search-target';
+import { TaggedCharacter } from '../lib/tagged-character';
+
+interface LoadCharacters {
+  type: 'load-characters';
+  characters: TaggedCharacter[];
+}
+
+interface ChangeSearchTargetAction {
+  type: 'change-search-target';
+  target: SearchTarget;
+}
+
+interface ChangeSearchWordsAction {
+  type: 'change-search-words';
+  words: string[];
+}
+
+interface ChangeShowAllAction {
+  type: 'change-show-all';
+  showAll: boolean;
+}
+
+interface ClickTag {
+  type: 'click-tag';
+  label: string;
+}
+
+export type Action =
+  | LoadCharacters
+  | ChangeSearchTargetAction
+  | ChangeSearchWordsAction
+  | ChangeShowAllAction
+  | ClickTag;

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -1,0 +1,144 @@
+import { SearchTarget } from '../lib/search-target';
+import { filterCharacters, TaggedCharacter } from '../lib/tagged-character';
+import {
+  onChangeSearchTarget,
+  onChangeSearchWords,
+  onChangeShowAll,
+  onClickTag,
+  onLoadCharacters,
+} from './dispatch';
+import { State } from './state';
+
+jest.mock('../lib/tagged-character');
+
+describe('各dispatchの対応', () => {
+  const state: Readonly<State> = {
+    characters: [],
+    search: {
+      target: SearchTarget.TAG,
+      words: [],
+      showAll: false,
+      results: [],
+    },
+  };
+
+  beforeEach(() => {
+    (filterCharacters as unknown as jest.Mock).mockReturnValue([]);
+  });
+
+  describe('onLoadCharacters', () => {
+    let nextState: State;
+    const characterShowDefault: TaggedCharacter = {
+      name: 'name',
+      tags: [
+        {
+          category: 'category',
+          label: 'label',
+        },
+      ],
+      showDefault: true,
+    };
+    const characterHiddenDefault: TaggedCharacter = {
+      name: 'name-hidden',
+      tags: [
+        {
+          category: 'category',
+          label: 'label',
+        },
+      ],
+      showDefault: false,
+    };
+    const characters: TaggedCharacter[] = [
+      characterShowDefault,
+      characterHiddenDefault,
+    ];
+
+    beforeEach(() => {
+      nextState = onLoadCharacters(state, characters);
+    });
+
+    it('キャラクターが追加される', () => {
+      expect(nextState.characters).toEqual(characters);
+    });
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  });
+
+  describe('onChangeSearchTarget', () => {
+    let nextState: State;
+    const target = SearchTarget.NAME;
+
+    beforeEach(() => {
+      nextState = onChangeSearchTarget(state, target);
+    });
+
+    it('検索対象が変更されている', () => {
+      expect(nextState.search.target).toBe(target);
+    });
+
+    it('検索ワードがリセットされている', () => {
+      expect(nextState.search.words).toEqual([]);
+    });
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  });
+
+  describe('onChangeSearchWords', () => {
+    let nextState: State;
+    const words = ['word'];
+
+    beforeEach(() => {
+      nextState = onChangeSearchWords(state, words);
+    });
+
+    it('検索ワードが変更されている', () => {
+      expect(nextState.search.words).toEqual(words);
+    });
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  });
+
+  describe('onChangeShowAll', () => {
+    let nextState: State;
+    const showAll = true;
+
+    beforeEach(() => {
+      nextState = onChangeShowAll(state, showAll);
+    });
+
+    it('全キャラ表示フラグが変更されている', () => {
+      expect(nextState.search.showAll).toBe(showAll);
+    });
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  });
+
+  describe('onClickTag', () => {
+    let nextState: State;
+    const label = 'label';
+
+    beforeEach(() => {
+      nextState = onClickTag(state, label);
+    });
+
+    it('検索対象がタグになっている', () => {
+      expect(nextState.search.target).toBe(SearchTarget.TAG);
+    });
+
+    it('検索ワードがクリックしたタグのみになっている', () => {
+      expect(nextState.search.words).toEqual([label]);
+    });
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  });
+});

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -1,0 +1,84 @@
+import { SearchTarget } from '../lib/search-target';
+import { filterCharacters, TaggedCharacter } from '../lib/tagged-character';
+import { State } from './state';
+
+export const onLoadCharacters = (
+  state: State,
+  characters: TaggedCharacter[]
+): State => {
+  const { search } = state;
+  const { target, words, showAll } = search;
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    characters,
+    search: {
+      ...search,
+      results,
+    },
+  };
+};
+
+export const onChangeSearchTarget = (
+  state: State,
+  target: SearchTarget
+): State => {
+  const { characters, search } = state;
+  const { showAll } = search;
+  const words = [];
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      target,
+      words,
+      results,
+    },
+  };
+};
+
+export const onChangeSearchWords = (state: State, words: string[]): State => {
+  const { characters, search } = state;
+  const { target, showAll } = search;
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      words,
+      results,
+    },
+  };
+};
+
+export const onChangeShowAll = (state: State, showAll: boolean): State => {
+  const { characters, search } = state;
+  const { target, words } = search;
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      showAll,
+      results,
+    },
+  };
+};
+
+export const onClickTag = (state: State, label: string): State => {
+  const { characters, search } = state;
+  const { showAll } = search;
+  const target = SearchTarget.TAG;
+  const words = [label];
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      target,
+      words,
+      results,
+    },
+  };
+};

--- a/src/flux/index.ts
+++ b/src/flux/index.ts
@@ -1,0 +1,11 @@
+import { useReducer } from 'react';
+import { reducer } from './reducer';
+import { initialState } from './state';
+
+export const useFlux = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return {
+    state,
+    dispatch,
+  };
+};

--- a/src/flux/reducer.spec.ts
+++ b/src/flux/reducer.spec.ts
@@ -1,0 +1,43 @@
+import { Action } from './action';
+import {
+  onChangeSearchTarget,
+  onChangeSearchWords,
+  onChangeShowAll,
+  onClickTag,
+  onLoadCharacters,
+} from './dispatch';
+import { reducer } from './reducer';
+import { initialState } from './state';
+
+jest.mock('./dispatch');
+
+describe('reducer', () => {
+  const state = initialState;
+
+  describe.each`
+    type                      | method
+    ${'load-characters'}      | ${onLoadCharacters}
+    ${'change-search-target'} | ${onChangeSearchTarget}
+    ${'change-search-words'}  | ${onChangeSearchWords}
+    ${'change-show-all'}      | ${onChangeShowAll}
+    ${'click-tag'}            | ${onClickTag}
+  `('action.typeが$typeのとき', ({ type, method }) => {
+    beforeEach(() => {
+      reducer(state, { type } as unknown as Action);
+    });
+    it(`${method.name}が呼ばれる`, () => {
+      expect(method).toBeCalled();
+    });
+  });
+  describe('actionがどれにも当てはまらないとき', () => {
+    const action = {
+      type: 'unknown',
+    } as unknown as Action;
+
+    it('エラーが返る', () => {
+      expect(() => reducer(state, action)).toThrowError(
+        'Invalid dispatch action'
+      );
+    });
+  });
+});

--- a/src/flux/reducer.ts
+++ b/src/flux/reducer.ts
@@ -1,86 +1,13 @@
 import { Reducer } from 'react';
-import { SearchTarget } from '../lib/search-target';
-import { filterCharacters, TaggedCharacter } from '../lib/tagged-character';
 import { Action } from './action';
+import {
+  onChangeSearchTarget,
+  onChangeSearchWords,
+  onChangeShowAll,
+  onClickTag,
+  onLoadCharacters,
+} from './dispatch';
 import { State } from './state';
-
-const onLoadCharacters = (
-  state: State,
-  characters: TaggedCharacter[]
-): State => {
-  const { search } = state;
-  const { target, words, showAll } = search;
-  const results = filterCharacters(characters, target, words, showAll);
-  return {
-    ...state,
-    characters,
-    search: {
-      ...search,
-      results,
-    },
-  };
-};
-
-const onChangeSearchTarget = (state: State, target: SearchTarget): State => {
-  const { characters, search } = state;
-  const { showAll } = search;
-  const words = [];
-  const results = filterCharacters(characters, target, words, showAll);
-  return {
-    ...state,
-    search: {
-      ...search,
-      target,
-      words,
-      results,
-    },
-  };
-};
-
-const onChangeSearchWords = (state: State, words: string[]): State => {
-  const { characters, search } = state;
-  const { target, showAll } = search;
-  const results = filterCharacters(characters, target, words, showAll);
-  return {
-    ...state,
-    search: {
-      ...search,
-      words,
-      results,
-    },
-  };
-};
-
-const onChangeShowAll = (state: State, showAll: boolean): State => {
-  const { characters, search } = state;
-  const { target, words } = search;
-  const results = filterCharacters(characters, target, words, showAll);
-  return {
-    ...state,
-    search: {
-      ...search,
-      showAll,
-      results,
-    },
-  };
-};
-
-const onClickTag = (state: State, label: string): State => {
-  const { characters, search } = state;
-  const { showAll } = search;
-  const target = SearchTarget.TAG;
-  const words = [label];
-  const results = filterCharacters(characters, target, words, showAll);
-  return {
-    ...state,
-    search: {
-      ...search,
-      target,
-      words,
-      results,
-    },
-  };
-};
 
 export const reducer: Reducer<State, Action> = (state, action) => {
   switch (action.type) {

--- a/src/flux/reducer.ts
+++ b/src/flux/reducer.ts
@@ -1,0 +1,100 @@
+import { Reducer } from 'react';
+import { SearchTarget } from '../lib/search-target';
+import { filterCharacters, TaggedCharacter } from '../lib/tagged-character';
+import { Action } from './action';
+import { State } from './state';
+
+const onLoadCharacters = (
+  state: State,
+  characters: TaggedCharacter[]
+): State => {
+  const { search } = state;
+  const { target, words, showAll } = search;
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    characters,
+    search: {
+      ...search,
+      results,
+    },
+  };
+};
+
+const onChangeSearchTarget = (state: State, target: SearchTarget): State => {
+  const { characters, search } = state;
+  const { showAll } = search;
+  const words = [];
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      target,
+      words,
+      results,
+    },
+  };
+};
+
+const onChangeSearchWords = (state: State, words: string[]): State => {
+  const { characters, search } = state;
+  const { target, showAll } = search;
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      words,
+      results,
+    },
+  };
+};
+
+const onChangeShowAll = (state: State, showAll: boolean): State => {
+  const { characters, search } = state;
+  const { target, words } = search;
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      showAll,
+      results,
+    },
+  };
+};
+
+const onClickTag = (state: State, label: string): State => {
+  const { characters, search } = state;
+  const { showAll } = search;
+  const target = SearchTarget.TAG;
+  const words = [label];
+  const results = filterCharacters(characters, target, words, showAll);
+  return {
+    ...state,
+    search: {
+      ...search,
+      target,
+      words,
+      results,
+    },
+  };
+};
+
+export const reducer: Reducer<State, Action> = (state, action) => {
+  switch (action.type) {
+    case 'load-characters':
+      return onLoadCharacters(state, action.characters);
+    case 'change-search-target':
+      return onChangeSearchTarget(state, action.target);
+    case 'change-search-words':
+      return onChangeSearchWords(state, action.words);
+    case 'change-show-all':
+      return onChangeShowAll(state, action.showAll);
+    case 'click-tag':
+      return onClickTag(state, action.label);
+    default:
+      throw new Error('Invalid dispatch action');
+  }
+};

--- a/src/flux/state.ts
+++ b/src/flux/state.ts
@@ -1,0 +1,24 @@
+import { SearchTarget } from '../lib/search-target';
+import { TaggedCharacter } from '../lib/tagged-character';
+
+interface SearchState {
+  target: SearchTarget;
+  words: string[];
+  showAll: boolean;
+  results: TaggedCharacter[];
+}
+
+export interface State {
+  characters: TaggedCharacter[];
+  search: SearchState;
+}
+
+export const initialState: State = {
+  characters: [],
+  search: {
+    target: SearchTarget.TAG,
+    words: [],
+    showAll: false,
+    results: [],
+  },
+};

--- a/src/lib/tagged-character.spec.ts
+++ b/src/lib/tagged-character.spec.ts
@@ -1,7 +1,9 @@
+import { SearchTarget } from './search-target';
 import {
   filterCharactersByTagLabels,
   TaggedCharacter,
   filterCharactersByNameWords,
+  filterCharacters,
 } from './tagged-character';
 
 describe('filterCharactersByTagLabels', () => {
@@ -196,6 +198,45 @@ describe('searchCharactersByCharacterNameWords', () => {
           filterCharactersByNameWords(characters, [], false)
         ).toStrictEqual([alpha, beta, delta]);
       });
+    });
+  });
+});
+
+describe('filterCharacters', () => {
+  const characterWithTag = {
+    name: '',
+    tags: [
+      {
+        category: 'category',
+        label: 'label',
+      },
+    ],
+    showDefault: true,
+  };
+  const characterWithName = {
+    name: 'name',
+    tags: [],
+    showDefault: true,
+  };
+  const characters = [characterWithTag, characterWithName];
+
+  describe('検索対象がタグの場合', () => {
+    const searchTarget = SearchTarget.TAG;
+
+    it('タグ検索の結果が返る', () => {
+      expect(
+        filterCharacters(characters, searchTarget, ['label'], false)
+      ).toEqual([characterWithTag]);
+    });
+  });
+
+  describe('検索対象が名前の場合', () => {
+    const searchTarget = SearchTarget.NAME;
+
+    it('名前検索の結果が返る', () => {
+      expect(
+        filterCharacters(characters, searchTarget, ['name'], false)
+      ).toEqual([characterWithName]);
     });
   });
 });

--- a/src/lib/tagged-character.ts
+++ b/src/lib/tagged-character.ts
@@ -1,3 +1,5 @@
+import { SearchTarget } from './search-target';
+
 export interface Tag {
   category: string;
   label: string;
@@ -33,4 +35,18 @@ export const filterCharactersByNameWords = (
       (showAll || showDefault) && nameWords.every((word) => name.includes(word))
     );
   });
+};
+
+export const filterCharacters = (
+  characters: TaggedCharacter[],
+  target: SearchTarget,
+  words: string[],
+  showAll: boolean
+): TaggedCharacter[] => {
+  switch (target) {
+    case SearchTarget.TAG:
+      return filterCharactersByTagLabels(characters, words, showAll);
+    case SearchTarget.NAME:
+      return filterCharactersByNameWords(characters, words, showAll);
+  }
 };


### PR DESCRIPTION
- `useReducer` を使ってfluxっぽい仕組みを作る
    - stateとdispatch
    - 「複数の値にまたがる複雑なstateロジック」「前の state に基づいて次の state を決める」など公式docに書かれていることと一致するので採用
- `CharactersSearcher` でstate, dispatchを受け取ってハンドラを作り各コンポーネントに配布する
    - 将来的には各organismレベルでハンドラを作りたい
    - ちゃんとやるなら `useContext` との組み合わせが必要なので一旦見送り
- 全キャラ表示の切り替えが1秒くらい早くなった
    - OFF→ONの切り替えはまだ重いが、ON→OFFの切り替えはそこまで重いと感じない
    - OFF→ONに関しては、描画するDOM量の多さが根本問題っぽそう
    - キャラ数絞るのがベストな気がする
- おまけ: キャラ検索用のラッパー関数を実装
    - タグでも名前でも同じ関数
    - dipatcherで結構検索するので、その都度分岐書くのは面倒だった