### PR TITLE
重複するタグラベルはタグ表示時に削る

### DIFF
--- a/src/components/molecules/CharacterCard.stories.tsx
+++ b/src/components/molecules/CharacterCard.stories.tsx
@@ -37,3 +37,14 @@ OverflowTags.args = {
   })),
   sx: {},
 };
+
+export const DuplicateTagLabels = Template.bind({});
+DuplicateTagLabels.args = {
+  name: 'なまえ',
+  tags: [
+    { category: 'あいうえお', label: 'タグ1' },
+    { category: 'かきくけこ', label: 'タグ2' },
+    { category: 'さしすせそ', label: 'タグ2' },
+  ],
+  sx: {},
+};

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -33,7 +33,7 @@ interface Props {
 
 export const CharacterCard: React.FC<Props> = React.memo(
   function CharacterCard({ name, tags, onClickTag, sx }) {
-    const tagLabels = tags.map(({ label }) => label);
+    const tagLabels = Array.from(new Set(tags.map(({ label }) => label)));
     return (
       <Card elevation={2} sx={sx}>
         <CardHeader title={name} />

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -45,8 +45,8 @@ export const CharacterCard: React.FC<Props> = React.memo(
               spacing={1}
               sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
             >
-              {tagLabels.map((tagLabel, index) => (
-                <TagBadge key={index} onClick={onClickTag}>
+              {tagLabels.map((tagLabel) => (
+                <TagBadge key={tagLabel} onClick={onClickTag}>
                   {tagLabel}
                 </TagBadge>
               ))}


### PR DESCRIPTION
- ラベルが重複するタグは1つだけ表示する
    - 検索時にはラベルしか見ないのでこれでも問題ない
- おまけ: タグ表示のkeyをindexからlabelに戻す
    - ラベル重複を気にしなくてよくなったため