### PR TITLE
moizeを使って全体を通してコンポーネントをメモ化する

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fontsource/noto-sans-jp": "^4.5.10",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.2",
+    "moize": "^6.1.2",
     "next": "^12.2.3",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",

--- a/src/components/atoms/TagBadge.tsx
+++ b/src/components/atoms/TagBadge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from '@mui/material/Button';
 import { SxProps, Theme } from '@mui/material';
+import { memoizedComponent } from '../../lib/memoized';
 
 interface Props {
   /**
@@ -18,23 +19,21 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const TagBadge: React.FC<Props> = React.memo(function TagBadge({
-  children,
-  onClick,
-  sx,
-}) {
-  const onClickButton = React.useCallback(
-    () => onClick(children),
-    [onClick, children]
-  );
-  return (
-    <Button
-      size="small"
-      variant="outlined"
-      onClick={onClickButton}
-      sx={{ textTransform: 'none', ...sx }}
-    >
-      {children}
-    </Button>
-  );
-});
+export const TagBadge = memoizedComponent<React.FC<Props>>(
+  ({ children: children, onClick, sx }) => {
+    const onClickButton = React.useCallback(
+      () => onClick(children),
+      [onClick, children]
+    );
+    return (
+      <Button
+        size="small"
+        variant="outlined"
+        onClick={onClickButton}
+        sx={{ textTransform: 'none', ...sx }}
+      >
+        {children}
+      </Button>
+    );
+  }
+);

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { TagBadge } from '../atoms/TagBadge';
 import Stack from '@mui/material/Stack';
 import { Tag } from '../../lib/tagged-character';
+import { memoizedComponent } from '../../lib/memoized';
 
 interface Props {
   /**
@@ -31,8 +32,8 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const CharacterCard: React.FC<Props> = React.memo(
-  function CharacterCard({ name, tags, onClickTag, sx }) {
+export const CharacterCard = memoizedComponent<React.FC<Props>>(
+  ({ name, tags, onClickTag, sx }) => {
     const tagLabels = Array.from(new Set(tags.map(({ label }) => label)));
     return (
       <Card elevation={2} sx={sx}>

--- a/src/lib/memoized.ts
+++ b/src/lib/memoized.ts
@@ -1,0 +1,10 @@
+import moize from 'moize';
+
+export const memoizedComponent = moize.compose(
+  // moize.reactを使うと各インスタンスごとのメモ化になる(React.memoと同様)
+  // 全体を通してのメモ化がしたいので、shallowとmaxArgs(2)で対応
+  // https://planttheidea.github.io/moize/#isreact
+  moize.shallow,
+  moize.maxArgs(2),
+  moize.infinite
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6465,6 +6465,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-equals@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-3.0.3.tgz#8e6cb4e51ca1018d87dd41982ef92758b3e4197f"
+  integrity sha512-NCe8qxnZFARSHGztGMZOO/PC1qa5MIFB5Hp66WdzbCRAz8U8US3bx1UTgLS49efBQPcUtO9gf5oVEY8o7y/7Kg==
+
 fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -9095,6 +9100,11 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
+micro-memoize@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-4.0.11.tgz#f664afc8bd8c11cb2838716a7306d6e1ec205d3a"
+  integrity sha512-CjxsaYe4j43df32DtzzNCwanPqZjZDwuQAZilsCYpa2ZVtSPDjHXbTlR4gsEZRyO9/twHs0b7HLjvy/sowl7sA==
+
 microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
@@ -9277,6 +9287,14 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moize@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/moize/-/moize-6.1.2.tgz#fb6f48d4487de13021b9ff11c569a577f82cba88"
+  integrity sha512-ITAy0ynIrWR9PVHIu9GqRcGSqia+lDsE+mxVkvBbl/O2J1O6JAaV2YYDtd82AUv2RXK/7GQRjUA/c0y6D/1b1A==
+  dependencies:
+    fast-equals "^3.0.1"
+    micro-memoize "^4.0.11"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#57

- メモ化のライブラリとして `moize` を導入
    - https://planttheidea.github.io/moize
- moizeを使って `TagBadge` `CharacterCard` をメモ化
    - インスタンスごとではなく全体のメモ化
    - 例: 同じタグとクリックハンドラなら別の場所でも `TagBadge` がメモ化される
- 開発環境で現時点のproductionと同じくらいのパフォーマンス
    - DOMが増えるときはちょっと重い
    - 初回書き込みとDOMが減るときは速くなった
- 注意: メモ化の最大容量に制限がないからメモリいっぱい食うかも