### PR TITLE
モバイルでのデザイン調整

### DIFF
--- a/src/components/atoms/SearchTargetSelect.tsx
+++ b/src/components/atoms/SearchTargetSelect.tsx
@@ -40,13 +40,16 @@ export const SearchTargetSelect: React.FC<Props> = ({
     [onChange]
   );
   const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'))
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   return (
     <Select
       value={target}
       onChange={onSelect}
-      sx={{ fontSize: isTabletOrDesktop ? theme.typography.h5 : theme.typography.h6, ...sx }}
+      sx={{
+        fontSize: isTabletOrDesktop ? theme.typography.h5 : theme.typography.h6,
+        ...sx,
+      }}
     >
       <MenuItem value={SearchTarget.TAG}>タグで検索する</MenuItem>
       <MenuItem value={SearchTarget.NAME}>名前で検索する</MenuItem>

--- a/src/components/atoms/SearchTargetSelect.tsx
+++ b/src/components/atoms/SearchTargetSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import { SxProps, Theme, useTheme } from '@mui/material';
+import { SxProps, Theme, useMediaQuery, useTheme } from '@mui/material';
 import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
@@ -40,12 +40,13 @@ export const SearchTargetSelect: React.FC<Props> = ({
     [onChange]
   );
   const theme = useTheme();
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'))
 
   return (
     <Select
       value={target}
       onChange={onSelect}
-      sx={{ fontSize: theme.typography.h5, ...sx }}
+      sx={{ fontSize: isTabletOrDesktop ? theme.typography.h5 : theme.typography.h6, ...sx }}
     >
       <MenuItem value={SearchTarget.TAG}>タグで検索する</MenuItem>
       <MenuItem value={SearchTarget.NAME}>名前で検索する</MenuItem>

--- a/src/components/molecules/AutocompleteForm.tsx
+++ b/src/components/molecules/AutocompleteForm.tsx
@@ -4,6 +4,7 @@ import {
   SxProps,
   TextField,
   Theme,
+  useMediaQuery,
   useTheme,
 } from '@mui/material';
 import React from 'react';
@@ -53,6 +54,7 @@ export const AutocompleteForm: React.FC<Props> = ({
     [onChange]
   );
   const theme = useTheme();
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'))
 
   return (
     <Autocomplete
@@ -79,7 +81,7 @@ export const AutocompleteForm: React.FC<Props> = ({
           placeholder={placeholder}
           inputProps={{
             ...params.inputProps,
-            sx: { fontSize: theme.typography.h5 },
+            sx: { fontSize: isTabletOrDesktop ? theme.typography.h5 : theme.typography.h6 },
           }}
         />
       )}

--- a/src/components/molecules/AutocompleteForm.tsx
+++ b/src/components/molecules/AutocompleteForm.tsx
@@ -54,7 +54,7 @@ export const AutocompleteForm: React.FC<Props> = ({
     [onChange]
   );
   const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'))
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   return (
     <Autocomplete
@@ -81,7 +81,11 @@ export const AutocompleteForm: React.FC<Props> = ({
           placeholder={placeholder}
           inputProps={{
             ...params.inputProps,
-            sx: { fontSize: isTabletOrDesktop ? theme.typography.h5 : theme.typography.h6 },
+            sx: {
+              fontSize: isTabletOrDesktop
+                ? theme.typography.h5
+                : theme.typography.h6,
+            },
           }}
         />
       )}

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -5,6 +5,8 @@ import {
   CardHeader,
   SxProps,
   Theme,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import React from 'react';
 import { TagBadge } from '../atoms/TagBadge';
@@ -35,9 +37,18 @@ interface Props {
 export const CharacterCard = memoizedComponent<React.FC<Props>>(
   ({ name, tags, onClickTag, sx }) => {
     const tagLabels = Array.from(new Set(tags.map(({ label }) => label)));
+    const theme = useTheme();
+    const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
+
     return (
       <Card elevation={2} sx={sx}>
-        <CardHeader title={name} />
+        <CardHeader
+          title={name}
+          titleTypographyProps={{
+            component: 'h5',
+            variant: isTabletOrDesktop ? 'h5' : 'h6',
+          }}
+        />
         <CardContent>
           {/* スクロールバーがタグと被らないように下部余白を確保する */}
           <Box pb={1} sx={{ overflowX: 'scroll' }}>

--- a/src/components/molecules/SearchTargetAndWords.tsx
+++ b/src/components/molecules/SearchTargetAndWords.tsx
@@ -1,4 +1,4 @@
-import { SxProps, Theme, Typography } from '@mui/material';
+import { SxProps, Theme, Typography, useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 import { SearchTarget } from '../../lib/search-target';
 
@@ -24,12 +24,15 @@ export const SearchTargetAndWords: React.FC<Props> = ({
 }) => {
   const targetStr = target === SearchTarget.TAG ? 'タグ' : '名前';
   const joinedText = words.join(' ');
+  const theme = useTheme();
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'))
+  const variant = isTabletOrDesktop ? "h5" : "h6"
 
   return (
-    <Typography variant="h5" sx={sx}>
+    <Typography component="h5" variant={variant} sx={sx}>
       {joinedText ? (
         <>
-          <Typography component="span" variant="h5" fontWeight="bold">
+          <Typography component="span" variant={variant} fontWeight="bold">
             {joinedText}
           </Typography>
           の{targetStr}検索結果

--- a/src/components/molecules/SearchTargetAndWords.tsx
+++ b/src/components/molecules/SearchTargetAndWords.tsx
@@ -1,4 +1,10 @@
-import { SxProps, Theme, Typography, useMediaQuery, useTheme } from '@mui/material';
+import {
+  SxProps,
+  Theme,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import React from 'react';
 import { SearchTarget } from '../../lib/search-target';
 
@@ -25,8 +31,8 @@ export const SearchTargetAndWords: React.FC<Props> = ({
   const targetStr = target === SearchTarget.TAG ? 'タグ' : '名前';
   const joinedText = words.join(' ');
   const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'))
-  const variant = isTabletOrDesktop ? "h5" : "h6"
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
+  const variant = isTabletOrDesktop ? 'h5' : 'h6';
 
   return (
     <Typography component="h5" variant={variant} sx={sx}>

--- a/src/components/organisms/SearchCondition.stories.tsx
+++ b/src/components/organisms/SearchCondition.stories.tsx
@@ -18,6 +18,5 @@ const Template: ComponentStory<typeof SearchCondition> = (args) => (
 
 export const Condition = Template.bind({});
 Condition.args = {
-  character: 'キャラクター',
   sx: {},
 };

--- a/src/components/organisms/SearchCondition.tsx
+++ b/src/components/organisms/SearchCondition.tsx
@@ -1,4 +1,4 @@
-import { Stack, SxProps, Theme } from '@mui/material';
+import { Stack, SxProps, Theme, useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 import { FluxContext } from '../../flux/context';
 import { SearchTargetAndWords } from '../molecules/SearchTargetAndWords';
@@ -21,12 +21,14 @@ export const SearchCondition: React.FC<Props> = ({ sx }) => {
     },
     [dispatch]
   );
+  const theme = useTheme();
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   return (
     <Stack
-      direction="row"
-      alignItems="center"
-      justifyContent="space-between"
+      direction={isTabletOrDesktop ? 'row' : 'column'}
+      alignItems={isTabletOrDesktop ? 'center' : 'stretch'}
+      justifyContent={isTabletOrDesktop ? 'space-between' : 'flex-start'}
       sx={sx}
     >
       <SearchTargetAndWords target={target} words={words} />

--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -68,7 +68,7 @@ export const SearchForm: React.FC<Props> = ({ sx }) => {
   ) : (
     <Accordion elevation={2} sx={sx}>
       <AccordionSummary expandIcon={<ExpandMore />}>
-        <Typography variant="h5">検索フォーム</Typography>
+        <Typography component="p" variant="h6">検索フォーム</Typography>
       </AccordionSummary>
       <AccordionDetails>{form}</AccordionDetails>
     </Accordion>

--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Box from '@mui/material/Box';
-import { SxProps, Theme } from '@mui/material/styles';
+import { SxProps, Theme, useTheme } from '@mui/material/styles';
 import { SearchTargetSelect } from '../atoms/SearchTargetSelect';
 import { SearchTarget } from '../../lib/search-target';
 import { generateAutocompleteOptions } from '../../lib/autocomplete';
 import { FluxContext } from '../../flux/context';
 import { AutocompleteForm } from '../molecules/AutocompleteForm';
+import { Stack, useMediaQuery } from '@mui/material';
 
 interface Props {
   /**
@@ -34,17 +34,24 @@ export const SearchForm: React.FC<Props> = ({ sx }) => {
     target,
     showAll
   );
+  const theme = useTheme();
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   return (
-    <Box component="form" sx={{ display: 'flex', alignItems: 'center', ...sx }}>
+    <Stack
+      component="form"
+      direction={isTabletOrDesktop ? 'row' : 'column'}
+      alignItems={isTabletOrDesktop ? 'center' : 'stretch'}
+      spacing={2}
+      sx={sx}
+    >
       <SearchTargetSelect target={target} onChange={onChangeTarget} />
       <AutocompleteForm
         target={target}
         words={words}
         autocompleteOptions={autocompleteOptions}
         onChange={onChangeWords}
-        sx={{ ml: 2 }}
       />
-    </Box>
+    </Stack>
   );
 };

--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -5,7 +5,15 @@ import { SearchTarget } from '../../lib/search-target';
 import { generateAutocompleteOptions } from '../../lib/autocomplete';
 import { FluxContext } from '../../flux/context';
 import { AutocompleteForm } from '../molecules/AutocompleteForm';
-import { Stack, useMediaQuery } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Stack,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
+import { ExpandMore } from '@mui/icons-material';
 
 interface Props {
   /**
@@ -37,13 +45,13 @@ export const SearchForm: React.FC<Props> = ({ sx }) => {
   const theme = useTheme();
   const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
-  return (
+  const form = (
     <Stack
       component="form"
       direction={isTabletOrDesktop ? 'row' : 'column'}
       alignItems={isTabletOrDesktop ? 'center' : 'stretch'}
       spacing={2}
-      sx={sx}
+      sx={isTabletOrDesktop ? sx : undefined}
     >
       <SearchTargetSelect target={target} onChange={onChangeTarget} />
       <AutocompleteForm
@@ -53,5 +61,16 @@ export const SearchForm: React.FC<Props> = ({ sx }) => {
         onChange={onChangeWords}
       />
     </Stack>
+  );
+
+  return isTabletOrDesktop ? (
+    form
+  ) : (
+    <Accordion elevation={2} sx={sx}>
+      <AccordionSummary expandIcon={<ExpandMore />}>
+        <Typography variant="h5">検索フォーム</Typography>
+      </AccordionSummary>
+      <AccordionDetails>{form}</AccordionDetails>
+    </Accordion>
   );
 };

--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -68,7 +68,9 @@ export const SearchForm: React.FC<Props> = ({ sx }) => {
   ) : (
     <Accordion elevation={2} sx={sx}>
       <AccordionSummary expandIcon={<ExpandMore />}>
-        <Typography component="p" variant="h6">検索フォーム</Typography>
+        <Typography component="p" variant="h6">
+          検索フォーム
+        </Typography>
       </AccordionSummary>
       <AccordionDetails>{form}</AccordionDetails>
     </Accordion>

--- a/src/components/templates/SearchTemplate.tsx
+++ b/src/components/templates/SearchTemplate.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Container, LinearProgress, Typography } from '@mui/material';
+import {
+  Container,
+  LinearProgress,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { FluxContext } from '../../flux/context';
 import { SearchForm } from '../organisms/SearchForm';
 import { SearchCondition } from '../organisms/SearchCondition';
@@ -25,13 +31,17 @@ export const SearchTemplate: React.FC<Props> = ({ dataName }) => {
       })
       .catch(console.error);
   }, [dataName, dispatch]);
+  const theme = useTheme();
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   if (!state.isReady) {
     return <LinearProgress />;
   }
   return (
     <Container sx={{ py: 2 }}>
-      <Typography variant="h5">コンパチサーチ</Typography>
+      <Typography component="h1" variant={isTabletOrDesktop ? 'h5' : 'h6'}>
+        コンパチサーチ
+      </Typography>
       <SearchForm sx={{ mt: 2 }} />
       <SearchCondition sx={{ mt: 2 }} />
       <SearchResults sx={{ mt: 1 }} />

--- a/src/test-utils/flux.tsx
+++ b/src/test-utils/flux.tsx
@@ -9,6 +9,9 @@ export const initialTestState: State = {
   ...initialState,
   isReady: true,
   characters,
+  metadata: {
+    character: 'テストキャラクター',
+  },
   search: {
     ...initialState.search,
     target: SearchTarget.TAG,


### PR DESCRIPTION
Resolve #70 

- モバイルでは検索フォーム/検索条件の表示を横ではなく縦に並べる
- 検索フォームと検索条件がモバイルだと画面の半分を専有していたので縮める
    - 検索フォームをアコーディオンにする
    - 文字サイズを一回り縮める(h5→h6)