### PR TITLE
モバイル対応をなるべく減らして高速化を図る

### DIFF
--- a/src/components/atoms/SearchTargetSelect.tsx
+++ b/src/components/atoms/SearchTargetSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import { SxProps, Theme, useMediaQuery, useTheme } from '@mui/material';
+import { SxProps, Theme, useTheme } from '@mui/material';
 import { SearchTarget } from '../../lib/search-target';
 
 interface Props {
@@ -40,14 +40,13 @@ export const SearchTargetSelect: React.FC<Props> = ({
     [onChange]
   );
   const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   return (
     <Select
       value={target}
       onChange={onSelect}
       sx={{
-        fontSize: isTabletOrDesktop ? theme.typography.h5 : theme.typography.h6,
+        fontSize: theme.typography.h6,
         ...sx,
       }}
     >

--- a/src/components/molecules/AutocompleteForm.tsx
+++ b/src/components/molecules/AutocompleteForm.tsx
@@ -4,7 +4,6 @@ import {
   SxProps,
   TextField,
   Theme,
-  useMediaQuery,
   useTheme,
 } from '@mui/material';
 import React from 'react';
@@ -54,7 +53,6 @@ export const AutocompleteForm: React.FC<Props> = ({
     [onChange]
   );
   const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   return (
     <Autocomplete
@@ -82,9 +80,7 @@ export const AutocompleteForm: React.FC<Props> = ({
           inputProps={{
             ...params.inputProps,
             sx: {
-              fontSize: isTabletOrDesktop
-                ? theme.typography.h5
-                : theme.typography.h6,
+              fontSize: theme.typography.h6,
             },
           }}
         />

--- a/src/components/molecules/CharacterCard.tsx
+++ b/src/components/molecules/CharacterCard.tsx
@@ -5,8 +5,6 @@ import {
   CardHeader,
   SxProps,
   Theme,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import React from 'react';
 import { TagBadge } from '../atoms/TagBadge';
@@ -37,18 +35,10 @@ interface Props {
 export const CharacterCard = memoizedComponent<React.FC<Props>>(
   ({ name, tags, onClickTag, sx }) => {
     const tagLabels = Array.from(new Set(tags.map(({ label }) => label)));
-    const theme = useTheme();
-    const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
     return (
       <Card elevation={2} sx={sx}>
-        <CardHeader
-          title={name}
-          titleTypographyProps={{
-            component: 'h5',
-            variant: isTabletOrDesktop ? 'h5' : 'h6',
-          }}
-        />
+        <CardHeader title={name} />
         <CardContent>
           {/* スクロールバーがタグと被らないように下部余白を確保する */}
           <Box pb={1} sx={{ overflowX: 'scroll' }}>

--- a/src/components/molecules/SearchTargetAndWords.tsx
+++ b/src/components/molecules/SearchTargetAndWords.tsx
@@ -1,10 +1,4 @@
-import {
-  SxProps,
-  Theme,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import { SxProps, Theme, Typography } from '@mui/material';
 import React from 'react';
 import { SearchTarget } from '../../lib/search-target';
 
@@ -30,9 +24,7 @@ export const SearchTargetAndWords: React.FC<Props> = ({
 }) => {
   const targetStr = target === SearchTarget.TAG ? 'タグ' : '名前';
   const joinedText = words.join(' ');
-  const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
-  const variant = isTabletOrDesktop ? 'h5' : 'h6';
+  const variant = 'h6';
 
   return (
     <Typography component="h5" variant={variant} sx={sx}>

--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
   useMediaQuery,
 } from '@mui/material';
-import { ExpandMore } from '@mui/icons-material';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 
 interface Props {
   /**

--- a/src/components/templates/SearchTemplate.tsx
+++ b/src/components/templates/SearchTemplate.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  Container,
-  LinearProgress,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import { Container, LinearProgress, Typography } from '@mui/material';
 import { FluxContext } from '../../flux/context';
 import { SearchForm } from '../organisms/SearchForm';
 import { SearchCondition } from '../organisms/SearchCondition';
@@ -31,15 +25,13 @@ export const SearchTemplate: React.FC<Props> = ({ dataName }) => {
       })
       .catch(console.error);
   }, [dataName, dispatch]);
-  const theme = useTheme();
-  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
   if (!state.isReady) {
     return <LinearProgress />;
   }
   return (
     <Container sx={{ py: 2 }}>
-      <Typography component="h1" variant={isTabletOrDesktop ? 'h5' : 'h6'}>
+      <Typography component="h1" variant="h6">
         コンパチサーチ
       </Typography>
       <SearchForm sx={{ mt: 2 }} />


### PR DESCRIPTION
#76 

- モバイル対応が多いと遅くなるっぽいので極力減らしてみる
- おまけ: アイコンのimportはファイルまで指定する
    - `import { Delete } from '@mui/icons-material';` だとdev buildは遅いらしい
    - https://mui.com/material-ui/guides/minimizing-bundle-size/#development-environment