### PR TITLE
クリック時に検索中のタグを保持する

### DIFF
--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -146,20 +146,61 @@ describe('各dispatchの対応', () => {
     let nextState: State;
     const label = 'label';
 
-    beforeEach(() => {
-      nextState = onClickTag(state, label);
+    describe('今のstateがタグ検索のとき', () => {
+      const currentState: State = {
+        ...state,
+        search: {
+          ...state.search,
+          target: SearchTarget.TAG,
+          words: ['imano', 'tag'],
+        },
+      };
+
+      beforeEach(() => {
+        nextState = onClickTag(currentState, label);
+      });
+
+      it('検索対象がタグになっている', () => {
+        expect(nextState.search.target).toBe(SearchTarget.TAG);
+      });
+
+      it('既存の検索ワードにクリックしたタグが追加されている', () => {
+        expect(nextState.search.words).toEqual([
+          ...currentState.search.words,
+          label,
+        ]);
+      });
+
+      it('フィルタ関数が呼び出されている', () => {
+        expect(filterCharacters).toBeCalled();
+      });
     });
 
-    it('検索対象がタグになっている', () => {
-      expect(nextState.search.target).toBe(SearchTarget.TAG);
-    });
+    describe('今のstateが名前検索のとき', () => {
+      const currentState: State = {
+        ...state,
+        search: {
+          ...state.search,
+          target: SearchTarget.NAME,
+          words: ['imano', 'name'],
+        },
+      };
 
-    it('検索ワードがクリックしたタグのみになっている', () => {
-      expect(nextState.search.words).toEqual([label]);
-    });
+      beforeEach(() => {
+        nextState = onClickTag(currentState, label);
+      });
 
-    it('フィルタ関数が呼び出されている', () => {
-      expect(filterCharacters).toBeCalled();
+      it('検索対象がタグになっている', () => {
+        expect(nextState.search.target).toBe(SearchTarget.TAG);
+      });
+
+      it('検索ワードがクリックしたタグのみになっている', () => {
+        expect(nextState.search.words).toEqual([label]);
+      });
+
+      it('フィルタ関数が呼び出されている', () => {
+        expect(filterCharacters).toBeCalled();
+      });
     });
   });
 });

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -13,73 +13,157 @@ import { State } from './state';
 
 jest.mock('../lib/tagged-character');
 
-describe('各dispatchの対応', () => {
-  const state: Readonly<State> = {
-    isReady: false,
-    characters: [],
-    metadata: {
-      character: '',
-    },
-    search: {
-      target: SearchTarget.TAG,
-      words: [],
-      showAll: false,
-      results: [],
-    },
+const state: Readonly<State> = {
+  isReady: false,
+  characters: [],
+  metadata: {
+    character: '',
+  },
+  search: {
+    target: SearchTarget.TAG,
+    words: [],
+    showAll: false,
+    results: [],
+  },
+};
+
+describe('onLoadCharacters', () => {
+  let nextState: State;
+  const characterShowDefault: TaggedCharacter = {
+    name: 'name',
+    tags: [
+      {
+        category: 'category',
+        label: 'label',
+      },
+    ],
+    showDefault: true,
+  };
+  const characterHiddenDefault: TaggedCharacter = {
+    name: 'name-hidden',
+    tags: [
+      {
+        category: 'category',
+        label: 'label',
+      },
+    ],
+    showDefault: false,
+  };
+  const characters: TaggedCharacter[] = [
+    characterShowDefault,
+    characterHiddenDefault,
+  ];
+  const metadata: Metadata = {
+    character: 'きゃらくた',
+  };
+  const charactersData: CharactersData = {
+    characters,
+    metadata,
   };
 
   beforeEach(() => {
-    (filterCharacters as unknown as jest.Mock).mockReturnValue([]);
+    nextState = onLoadCharactersData(state, charactersData);
   });
 
-  describe('onLoadCharacters', () => {
-    let nextState: State;
-    const characterShowDefault: TaggedCharacter = {
-      name: 'name',
-      tags: [
-        {
-          category: 'category',
-          label: 'label',
-        },
-      ],
-      showDefault: true,
-    };
-    const characterHiddenDefault: TaggedCharacter = {
-      name: 'name-hidden',
-      tags: [
-        {
-          category: 'category',
-          label: 'label',
-        },
-      ],
-      showDefault: false,
-    };
-    const characters: TaggedCharacter[] = [
-      characterShowDefault,
-      characterHiddenDefault,
-    ];
-    const metadata: Metadata = {
-      character: 'きゃらくた',
-    };
-    const charactersData: CharactersData = {
-      characters,
-      metadata,
+  it('準備完了フラグが変更されている', () => {
+    expect(nextState.isReady).toBeTruthy();
+  });
+
+  it('キャラクターが変更されている', () => {
+    expect(nextState.characters).toEqual(characters);
+  });
+
+  it('メタデータが変更されている', () => {
+    expect(nextState.metadata).toEqual(metadata);
+  });
+
+  it('フィルタ関数が呼び出されている', () => {
+    expect(filterCharacters).toBeCalled();
+  });
+});
+
+describe('onChangeSearchTarget', () => {
+  let nextState: State;
+  const target = SearchTarget.NAME;
+
+  beforeEach(() => {
+    nextState = onChangeSearchTarget(state, target);
+  });
+
+  it('検索対象が変更されている', () => {
+    expect(nextState.search.target).toBe(target);
+  });
+
+  it('検索ワードがリセットされている', () => {
+    expect(nextState.search.words).toEqual([]);
+  });
+
+  it('フィルタ関数が呼び出されている', () => {
+    expect(filterCharacters).toBeCalled();
+  });
+});
+
+describe('onChangeSearchWords', () => {
+  let nextState: State;
+  const words = ['word'];
+
+  beforeEach(() => {
+    nextState = onChangeSearchWords(state, words);
+  });
+
+  it('検索ワードが変更されている', () => {
+    expect(nextState.search.words).toEqual(words);
+  });
+
+  it('フィルタ関数が呼び出されている', () => {
+    expect(filterCharacters).toBeCalled();
+  });
+});
+
+describe('onChangeShowAll', () => {
+  let nextState: State;
+  const showAll = true;
+
+  beforeEach(() => {
+    nextState = onChangeShowAll(state, showAll);
+  });
+
+  it('全キャラ表示フラグが変更されている', () => {
+    expect(nextState.search.showAll).toBe(showAll);
+  });
+
+  it('フィルタ関数が呼び出されている', () => {
+    expect(filterCharacters).toBeCalled();
+  });
+});
+
+describe('onClickTag', () => {
+  let nextState: State;
+  const label = 'label';
+
+  describe('今のstateがタグ検索のとき', () => {
+    const currentState: State = {
+      ...state,
+      search: {
+        ...state.search,
+        target: SearchTarget.TAG,
+        words: ['imano', 'tag'],
+      },
     };
 
     beforeEach(() => {
-      nextState = onLoadCharactersData(state, charactersData);
+      nextState = onClickTag(currentState, label);
     });
 
-    it('準備完了フラグが変更されている', () => {
-      expect(nextState.isReady).toBeTruthy();
+    it('検索対象がタグになっている', () => {
+      expect(nextState.search.target).toBe(SearchTarget.TAG);
     });
 
-    it('キャラクターが変更されている', () => {
-      expect(nextState.characters).toEqual(characters);
-    });
-
-    it('メタデータが変更されている', () => {
-      expect(nextState.metadata).toEqual(metadata);
+    it('既存の検索ワードにクリックしたタグが追加されている', () => {
+      expect(nextState.search.words).toEqual([
+        ...currentState.search.words,
+        label,
+      ]);
     });
 
     it('フィルタ関数が呼び出されている', () => {
@@ -87,120 +171,30 @@ describe('各dispatchの対応', () => {
     });
   });
 
-  describe('onChangeSearchTarget', () => {
-    let nextState: State;
-    const target = SearchTarget.NAME;
+  describe('今のstateが名前検索のとき', () => {
+    const currentState: State = {
+      ...state,
+      search: {
+        ...state.search,
+        target: SearchTarget.NAME,
+        words: ['imano', 'name'],
+      },
+    };
 
     beforeEach(() => {
-      nextState = onChangeSearchTarget(state, target);
+      nextState = onClickTag(currentState, label);
     });
 
-    it('検索対象が変更されている', () => {
-      expect(nextState.search.target).toBe(target);
+    it('検索対象がタグになっている', () => {
+      expect(nextState.search.target).toBe(SearchTarget.TAG);
     });
 
-    it('検索ワードがリセットされている', () => {
-      expect(nextState.search.words).toEqual([]);
+    it('検索ワードがクリックしたタグのみになっている', () => {
+      expect(nextState.search.words).toEqual([label]);
     });
 
     it('フィルタ関数が呼び出されている', () => {
       expect(filterCharacters).toBeCalled();
-    });
-  });
-
-  describe('onChangeSearchWords', () => {
-    let nextState: State;
-    const words = ['word'];
-
-    beforeEach(() => {
-      nextState = onChangeSearchWords(state, words);
-    });
-
-    it('検索ワードが変更されている', () => {
-      expect(nextState.search.words).toEqual(words);
-    });
-
-    it('フィルタ関数が呼び出されている', () => {
-      expect(filterCharacters).toBeCalled();
-    });
-  });
-
-  describe('onChangeShowAll', () => {
-    let nextState: State;
-    const showAll = true;
-
-    beforeEach(() => {
-      nextState = onChangeShowAll(state, showAll);
-    });
-
-    it('全キャラ表示フラグが変更されている', () => {
-      expect(nextState.search.showAll).toBe(showAll);
-    });
-
-    it('フィルタ関数が呼び出されている', () => {
-      expect(filterCharacters).toBeCalled();
-    });
-  });
-
-  describe('onClickTag', () => {
-    let nextState: State;
-    const label = 'label';
-
-    describe('今のstateがタグ検索のとき', () => {
-      const currentState: State = {
-        ...state,
-        search: {
-          ...state.search,
-          target: SearchTarget.TAG,
-          words: ['imano', 'tag'],
-        },
-      };
-
-      beforeEach(() => {
-        nextState = onClickTag(currentState, label);
-      });
-
-      it('検索対象がタグになっている', () => {
-        expect(nextState.search.target).toBe(SearchTarget.TAG);
-      });
-
-      it('既存の検索ワードにクリックしたタグが追加されている', () => {
-        expect(nextState.search.words).toEqual([
-          ...currentState.search.words,
-          label,
-        ]);
-      });
-
-      it('フィルタ関数が呼び出されている', () => {
-        expect(filterCharacters).toBeCalled();
-      });
-    });
-
-    describe('今のstateが名前検索のとき', () => {
-      const currentState: State = {
-        ...state,
-        search: {
-          ...state.search,
-          target: SearchTarget.NAME,
-          words: ['imano', 'name'],
-        },
-      };
-
-      beforeEach(() => {
-        nextState = onClickTag(currentState, label);
-      });
-
-      it('検索対象がタグになっている', () => {
-        expect(nextState.search.target).toBe(SearchTarget.TAG);
-      });
-
-      it('検索ワードがクリックしたタグのみになっている', () => {
-        expect(nextState.search.words).toEqual([label]);
-      });
-
-      it('フィルタ関数が呼び出されている', () => {
-        expect(filterCharacters).toBeCalled();
-      });
     });
   });
 });

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -30,6 +30,7 @@ const state: Readonly<State> = {
 describe('onLoadCharacters', () => {
   const currentState: State = {
     ...state,
+    isReady: false,
     characters: [],
     metadata: {
       character: '',

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -32,9 +32,9 @@ describe('onLoadCharacters', () => {
     ...state,
     characters: [],
     metadata: {
-      character: ''
-    }
-  }
+      character: '',
+    },
+  };
   let nextState: State;
   const characterShowDefault: TaggedCharacter = {
     name: 'name',
@@ -93,66 +93,69 @@ describe('onChangeSearchTarget', () => {
   let nextState: State;
 
   describe.each`
-  target
-  ${SearchTarget.TAG}
-  ${SearchTarget.NAME}
-  `("現在の検索対象と変更後の検索対象が一致する場合", ({target}) => {
+    target
+    ${SearchTarget.TAG}
+    ${SearchTarget.NAME}
+  `('現在の検索対象と変更後の検索対象が一致する場合', ({ target }) => {
     const currentState: State = {
       ...state,
       search: {
         ...state.search,
         target,
-        words: ['imano', 'tango']
-      }
-    }
+        words: ['imano', 'tango'],
+      },
+    };
 
     beforeEach(() => {
       nextState = onChangeSearchTarget(currentState, target);
     });
 
-    it("検索対象が変更されていない", () => {
+    it('検索対象が変更されていない', () => {
       expect(nextState.search.target).toBe(target);
-    })
+    });
 
-    it("検索ワードが変更されていない", () => {
-      expect(nextState.search.words).toEqual(currentState.search.words)
-    })
+    it('検索ワードが変更されていない', () => {
+      expect(nextState.search.words).toEqual(currentState.search.words);
+    });
 
     it('フィルタ関数が呼び出されている', () => {
       expect(filterCharacters).toBeCalled();
     });
-  })
+  });
 
   describe.each`
-  currentTarget | newTarget
-  ${SearchTarget.TAG} | ${SearchTarget.NAME}
-  ${SearchTarget.NAME} | ${SearchTarget.TAG}
-  `("現在の検索対象と変更後の検索対象が一致しない場合", ({currentTarget, newTarget}) => {
-    const currentState: State = {
-      ...state,
-      search: {
-        ...state.search,
-        target: currentTarget,
-        words: ['imano', 'tango']
-      }
+    currentTarget        | newTarget
+    ${SearchTarget.TAG}  | ${SearchTarget.NAME}
+    ${SearchTarget.NAME} | ${SearchTarget.TAG}
+  `(
+    '現在の検索対象と変更後の検索対象が一致しない場合',
+    ({ currentTarget, newTarget }) => {
+      const currentState: State = {
+        ...state,
+        search: {
+          ...state.search,
+          target: currentTarget,
+          words: ['imano', 'tango'],
+        },
+      };
+
+      beforeEach(() => {
+        nextState = onChangeSearchTarget(currentState, newTarget);
+      });
+
+      it('検索対象が変更されている', () => {
+        expect(nextState.search.target).toBe(newTarget);
+      });
+
+      it('検索ワードがリセットされている', () => {
+        expect(nextState.search.words).toEqual([]);
+      });
+
+      it('フィルタ関数が呼び出されている', () => {
+        expect(filterCharacters).toBeCalled();
+      });
     }
-
-    beforeEach(() => {
-      nextState = onChangeSearchTarget(currentState, newTarget);
-    });
-
-    it("検索対象が変更されている", () => {
-      expect(nextState.search.target).toBe(newTarget);
-    })
-
-    it("検索ワードがリセットされている", () => {
-      expect(nextState.search.words).toEqual([])
-    })
-
-    it('フィルタ関数が呼び出されている', () => {
-      expect(filterCharacters).toBeCalled();
-    });
-  })
+  );
 });
 
 describe('onChangeSearchWords', () => {
@@ -160,9 +163,9 @@ describe('onChangeSearchWords', () => {
     ...state,
     search: {
       ...state.search,
-      words: ['imano', 'kotoba']
-    }
-  }
+      words: ['imano', 'kotoba'],
+    },
+  };
   let nextState: State;
   const words = ['word'];
 
@@ -183,32 +186,35 @@ describe('onChangeShowAll', () => {
   let nextState: State;
 
   describe.each`
-  currentShowAll | newShowAll
-  ${true} | ${true}
-  ${true} | ${false}
-  ${false} | ${true}
-  ${false} | ${false}
-  `("現在の全キャラ表示フラグが $currentShowAll で変更後のフラグが $newShowAll の場合", ({currentShowAll, newShowAll}) => {
-    const currentState: State = {
-      ...state,
-      search: {
-        ...state.search,
-        showAll: currentShowAll,
-      }
+    currentShowAll | newShowAll
+    ${true}        | ${true}
+    ${true}        | ${false}
+    ${false}       | ${true}
+    ${false}       | ${false}
+  `(
+    '現在の全キャラ表示フラグが $currentShowAll で変更後のフラグが $newShowAll の場合',
+    ({ currentShowAll, newShowAll }) => {
+      const currentState: State = {
+        ...state,
+        search: {
+          ...state.search,
+          showAll: currentShowAll,
+        },
+      };
+
+      beforeEach(() => {
+        nextState = onChangeShowAll(currentState, newShowAll);
+      });
+
+      it('全キャラ表示フラグが変更後の値になっている', () => {
+        expect(nextState.search.showAll).toBe(newShowAll);
+      });
+
+      it('フィルタ関数が呼び出されている', () => {
+        expect(filterCharacters).toBeCalled();
+      });
     }
-
-    beforeEach(() => {
-      nextState = onChangeShowAll(currentState, newShowAll);
-    });
-
-    it('全キャラ表示フラグが変更後の値になっている', () => {
-      expect(nextState.search.showAll).toBe(newShowAll);
-    });
-
-    it('フィルタ関数が呼び出されている', () => {
-      expect(filterCharacters).toBeCalled();
-    });
-  })
+  );
 });
 
 describe('onClickTag', () => {

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -28,6 +28,13 @@ const state: Readonly<State> = {
 };
 
 describe('onLoadCharacters', () => {
+  const currentState: State = {
+    ...state,
+    characters: [],
+    metadata: {
+      character: ''
+    }
+  }
   let nextState: State;
   const characterShowDefault: TaggedCharacter = {
     name: 'name',
@@ -62,7 +69,7 @@ describe('onLoadCharacters', () => {
   };
 
   beforeEach(() => {
-    nextState = onLoadCharactersData(state, charactersData);
+    nextState = onLoadCharactersData(currentState, charactersData);
   });
 
   it('準備完了フラグが変更されている', () => {
@@ -84,31 +91,83 @@ describe('onLoadCharacters', () => {
 
 describe('onChangeSearchTarget', () => {
   let nextState: State;
-  const target = SearchTarget.NAME;
 
-  beforeEach(() => {
-    nextState = onChangeSearchTarget(state, target);
-  });
+  describe.each`
+  target
+  ${SearchTarget.TAG}
+  ${SearchTarget.NAME}
+  `("現在の検索対象と変更後の検索対象が一致する場合", ({target}) => {
+    const currentState: State = {
+      ...state,
+      search: {
+        ...state.search,
+        target,
+        words: ['imano', 'tango']
+      }
+    }
 
-  it('検索対象が変更されている', () => {
-    expect(nextState.search.target).toBe(target);
-  });
+    beforeEach(() => {
+      nextState = onChangeSearchTarget(currentState, target);
+    });
 
-  it('検索ワードがリセットされている', () => {
-    expect(nextState.search.words).toEqual([]);
-  });
+    it("検索対象が変更されていない", () => {
+      expect(nextState.search.target).toBe(target);
+    })
 
-  it('フィルタ関数が呼び出されている', () => {
-    expect(filterCharacters).toBeCalled();
-  });
+    it("検索ワードが変更されていない", () => {
+      expect(nextState.search.words).toEqual(currentState.search.words)
+    })
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  })
+
+  describe.each`
+  currentTarget | newTarget
+  ${SearchTarget.TAG} | ${SearchTarget.NAME}
+  ${SearchTarget.NAME} | ${SearchTarget.TAG}
+  `("現在の検索対象と変更後の検索対象が一致しない場合", ({currentTarget, newTarget}) => {
+    const currentState: State = {
+      ...state,
+      search: {
+        ...state.search,
+        target: currentTarget,
+        words: ['imano', 'tango']
+      }
+    }
+
+    beforeEach(() => {
+      nextState = onChangeSearchTarget(currentState, newTarget);
+    });
+
+    it("検索対象が変更されている", () => {
+      expect(nextState.search.target).toBe(newTarget);
+    })
+
+    it("検索ワードがリセットされている", () => {
+      expect(nextState.search.words).toEqual([])
+    })
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  })
 });
 
 describe('onChangeSearchWords', () => {
+  const currentState: State = {
+    ...state,
+    search: {
+      ...state.search,
+      words: ['imano', 'kotoba']
+    }
+  }
   let nextState: State;
   const words = ['word'];
 
   beforeEach(() => {
-    nextState = onChangeSearchWords(state, words);
+    nextState = onChangeSearchWords(currentState, words);
   });
 
   it('検索ワードが変更されている', () => {
@@ -122,19 +181,34 @@ describe('onChangeSearchWords', () => {
 
 describe('onChangeShowAll', () => {
   let nextState: State;
-  const showAll = true;
 
-  beforeEach(() => {
-    nextState = onChangeShowAll(state, showAll);
-  });
+  describe.each`
+  currentShowAll | newShowAll
+  ${true} | ${true}
+  ${true} | ${false}
+  ${false} | ${true}
+  ${false} | ${false}
+  `("現在の全キャラ表示フラグが $currentShowAll で変更後のフラグが $newShowAll の場合", ({currentShowAll, newShowAll}) => {
+    const currentState: State = {
+      ...state,
+      search: {
+        ...state.search,
+        showAll: currentShowAll,
+      }
+    }
 
-  it('全キャラ表示フラグが変更されている', () => {
-    expect(nextState.search.showAll).toBe(showAll);
-  });
+    beforeEach(() => {
+      nextState = onChangeShowAll(currentState, newShowAll);
+    });
 
-  it('フィルタ関数が呼び出されている', () => {
-    expect(filterCharacters).toBeCalled();
-  });
+    it('全キャラ表示フラグが変更後の値になっている', () => {
+      expect(nextState.search.showAll).toBe(newShowAll);
+    });
+
+    it('フィルタ関数が呼び出されている', () => {
+      expect(filterCharacters).toBeCalled();
+    });
+  })
 });
 
 describe('onClickTag', () => {

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -72,10 +72,10 @@ export const onChangeShowAll = (state: State, showAll: boolean): State => {
 
 export const onClickTag = (state: State, label: string): State => {
   const { characters, search } = state;
-  const { words: currentWords, target: currentTarget, showAll } = search;
+  const { showAll } = search;
   const target = SearchTarget.TAG;
   const words =
-    currentTarget === SearchTarget.TAG ? [...currentWords, label] : [label];
+    search.target === SearchTarget.TAG ? [...search.words, label] : [label];
   const results = filterCharacters(characters, target, words, showAll);
   return {
     ...state,

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -29,7 +29,7 @@ export const onChangeSearchTarget = (
 ): State => {
   const { characters, search } = state;
   const { showAll } = search;
-  const words = [];
+  const words = search.target === target ? search.words : [];
   const results = filterCharacters(characters, target, words, showAll);
   return {
     ...state,

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -72,9 +72,10 @@ export const onChangeShowAll = (state: State, showAll: boolean): State => {
 
 export const onClickTag = (state: State, label: string): State => {
   const { characters, search } = state;
-  const { showAll } = search;
+  const { words: currentWords, target: currentTarget, showAll } = search;
   const target = SearchTarget.TAG;
-  const words = [label];
+  const words =
+    currentTarget === SearchTarget.TAG ? [...currentWords, label] : [label];
   const results = filterCharacters(characters, target, words, showAll);
   return {
     ...state,


### PR DESCRIPTION
Resolve #53 
- クリック時に検索中のタグを保持する
    - 名前検索の場合はクリックしたタグだけで検索する
- おまけ: dispatchのテストを改修
    - 全体を包んでいたdispatchを剥がして見通しを良くする
    - テストケースをより細かく用意する