### PR TITLE
無限スクロールを導入してファーストビューに必要な要素数を絞る

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "next": "^12.2.3",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-infinite-scroller": "^1.2.6"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",
@@ -48,6 +49,7 @@
     "@types/jest": "^28.1.6",
     "@types/node": "^18.0.6",
     "@types/react": "^18.0.15",
+    "@types/react-infinite-scroller": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "babel-loader": "^8.2.5",

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -23,7 +23,7 @@ export const SearchResults: React.FC<Props> = ({ sx }) => {
     [dispatch]
   );
   const loadMore = React.useCallback(() => {
-    // loadMoreはpageをリセットしないのでsetPage側でいい感じに対応する
+    // react-infinite-scrollerはpageをリセットできないためflux側で管理する
     dispatch({
       type: 'show-next-page',
     });

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -30,7 +30,7 @@ export const SearchResults: React.FC<Props> = ({ sx }) => {
   }, [dispatch]);
   // 追加は12個ずつ
   // PCやタブレットだとファーストビューで12+α見えるため、初回だけ2ページ分表示する
-  const shownCharacters = characters.slice(0, page * 12);
+  const shownCharacters = characters.slice(0, (page + 1) * 12);
   const hasMore = shownCharacters.length < characters.length;
 
   return (

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -1,6 +1,7 @@
 import Grid from '@mui/material/Grid';
 import { SxProps, Theme } from '@mui/material/styles';
 import React from 'react';
+import InfiniteScroller from 'react-infinite-scroller';
 
 import { FluxContext } from '../../flux/context';
 import { CharacterCard } from '../molecules/CharacterCard';
@@ -14,21 +15,33 @@ interface Props {
 
 export const SearchResults: React.FC<Props> = ({ sx }) => {
   const { state, dispatch } = React.useContext(FluxContext);
-  const characters = state.search.results;
+  const { results: characters, page } = state.search;
   const onClickTag = React.useCallback(
     (label: string) => {
       dispatch({ type: 'click-tag', label });
     },
     [dispatch]
   );
+  const loadMore = React.useCallback(() => {
+    // loadMoreはpageをリセットしないのでsetPage側でいい感じに対応する
+    dispatch({
+      type: 'show-next-page',
+    });
+  }, [dispatch]);
+  // 追加は12個ずつ
+  // PCやタブレットだとファーストビューで12+α見えるため、初回だけ2ページ分表示する
+  const shownCharacters = characters.slice(0, page * 12);
+  const hasMore = shownCharacters.length < characters.length;
 
   return (
-    <Grid container spacing={2} sx={sx}>
-      {characters.map(({ name, tags }) => (
-        <Grid item key={name} xs={12} sm={6} md={4}>
-          <CharacterCard name={name} tags={tags} onClickTag={onClickTag} />
-        </Grid>
-      ))}
-    </Grid>
+    <InfiniteScroller loadMore={loadMore} hasMore={hasMore}>
+      <Grid container spacing={2} sx={sx}>
+        {shownCharacters.map(({ name, tags }) => (
+          <Grid item key={name} xs={12} sm={6} md={4}>
+            <CharacterCard name={name} tags={tags} onClickTag={onClickTag} />
+          </Grid>
+        ))}
+      </Grid>
+    </InfiniteScroller>
   );
 };

--- a/src/flux/action.ts
+++ b/src/flux/action.ts
@@ -26,9 +26,14 @@ interface ClickTag {
   label: string;
 }
 
+interface LoadMore {
+  type: 'show-next-page';
+}
+
 export type Action =
   | LoadCharactersData
   | ChangeSearchTargetAction
   | ChangeSearchWordsAction
   | ChangeShowAllAction
-  | ClickTag;
+  | ClickTag
+  | LoadMore;

--- a/src/flux/action.ts
+++ b/src/flux/action.ts
@@ -26,7 +26,7 @@ interface ClickTag {
   label: string;
 }
 
-interface LoadMore {
+interface ShowNextPage {
   type: 'show-next-page';
 }
 
@@ -36,4 +36,4 @@ export type Action =
   | ChangeSearchWordsAction
   | ChangeShowAllAction
   | ClickTag
-  | LoadMore;
+  | ShowNextPage;

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -9,6 +9,7 @@ import {
   onChangeShowAll,
   onClickTag,
   onLoadCharactersData,
+  onShowNextPage,
 } from './dispatch';
 import { State } from './state';
 
@@ -25,6 +26,7 @@ const state: Readonly<State> = {
     words: [],
     showAll: false,
     results: [],
+    page: 1,
   },
 };
 
@@ -105,6 +107,7 @@ describe('onChangeSearchTarget', () => {
         ...state.search,
         target,
         words: ['imano', 'tango'],
+        page: 5,
       },
     };
 
@@ -118,6 +121,10 @@ describe('onChangeSearchTarget', () => {
 
     it('検索ワードが変更されていない', () => {
       expect(nextState.search.words).toEqual(currentState.search.words);
+    });
+
+    it('ページがリセットされている', () => {
+      expect(nextState.search.page).toBe(1);
     });
 
     it('フィルタ関数が呼び出されている', () => {
@@ -138,6 +145,7 @@ describe('onChangeSearchTarget', () => {
           ...state.search,
           target: currentTarget,
           words: ['imano', 'tango'],
+          page: 5,
         },
       };
 
@@ -153,6 +161,10 @@ describe('onChangeSearchTarget', () => {
         expect(nextState.search.words).toEqual([]);
       });
 
+      it('ページがリセットされている', () => {
+        expect(nextState.search.page).toBe(1);
+      });
+
       it('フィルタ関数が呼び出されている', () => {
         expect(filterCharacters).toBeCalled();
       });
@@ -166,6 +178,7 @@ describe('onChangeSearchWords', () => {
     search: {
       ...state.search,
       words: ['imano', 'kotoba'],
+      page: 4,
     },
   };
   let nextState: State;
@@ -177,6 +190,10 @@ describe('onChangeSearchWords', () => {
 
   it('検索ワードが変更されている', () => {
     expect(nextState.search.words).toEqual(words);
+  });
+
+  it('ページがリセットされている', () => {
+    expect(nextState.search.page).toBe(1);
   });
 
   it('フィルタ関数が呼び出されている', () => {
@@ -201,6 +218,7 @@ describe('onChangeShowAll', () => {
         search: {
           ...state.search,
           showAll: currentShowAll,
+          page: 3,
         },
       };
 
@@ -210,6 +228,10 @@ describe('onChangeShowAll', () => {
 
       it('全キャラ表示フラグが変更後の値になっている', () => {
         expect(nextState.search.showAll).toBe(newShowAll);
+      });
+
+      it('ページがリセットされている', () => {
+        expect(nextState.search.page).toBe(1);
       });
 
       it('フィルタ関数が呼び出されている', () => {
@@ -230,6 +252,7 @@ describe('onClickTag', () => {
         ...state.search,
         target: SearchTarget.TAG,
         words: ['imano', 'tag'],
+        page: 2,
       },
     };
 
@@ -248,6 +271,10 @@ describe('onClickTag', () => {
       ]);
     });
 
+    it('ページがリセットされている', () => {
+      expect(nextState.search.page).toBe(1);
+    });
+
     it('フィルタ関数が呼び出されている', () => {
       expect(filterCharacters).toBeCalled();
     });
@@ -260,6 +287,7 @@ describe('onClickTag', () => {
         ...state.search,
         target: SearchTarget.NAME,
         words: ['imano', 'name'],
+        page: 2,
       },
     };
 
@@ -275,8 +303,31 @@ describe('onClickTag', () => {
       expect(nextState.search.words).toEqual([label]);
     });
 
+    it('ページがリセットされている', () => {
+      expect(nextState.search.page).toBe(1);
+    });
+
     it('フィルタ関数が呼び出されている', () => {
       expect(filterCharacters).toBeCalled();
     });
+  });
+});
+
+describe('onShowNextPage', () => {
+  let nextState: State;
+  const currentState = {
+    ...state,
+    search: {
+      ...state.search,
+      page: 1,
+    },
+  };
+
+  beforeEach(() => {
+    nextState = onShowNextPage(currentState);
+  });
+
+  it('pageが1つ増えている', () => {
+    expect(nextState.search.page).toBe(2);
   });
 });

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -15,7 +15,7 @@ import { State } from './state';
 
 jest.mock('../lib/filter-characters');
 
-const state: Readonly<State> = {
+const baseState: Readonly<State> = {
   isReady: false,
   characters: [],
   metadata: {
@@ -32,7 +32,7 @@ const state: Readonly<State> = {
 
 describe('onLoadCharacters', () => {
   const currentState: State = {
-    ...state,
+    ...baseState,
     isReady: false,
     characters: [],
     metadata: {
@@ -102,9 +102,9 @@ describe('onChangeSearchTarget', () => {
     ${SearchTarget.NAME}
   `('現在の検索対象と変更後の検索対象が一致する場合', ({ target }) => {
     const currentState: State = {
-      ...state,
+      ...baseState,
       search: {
-        ...state.search,
+        ...baseState.search,
         target,
         words: ['imano', 'tango'],
         page: 5,
@@ -140,9 +140,9 @@ describe('onChangeSearchTarget', () => {
     '現在の検索対象と変更後の検索対象が一致しない場合',
     ({ currentTarget, newTarget }) => {
       const currentState: State = {
-        ...state,
+        ...baseState,
         search: {
-          ...state.search,
+          ...baseState.search,
           target: currentTarget,
           words: ['imano', 'tango'],
           page: 5,
@@ -174,9 +174,9 @@ describe('onChangeSearchTarget', () => {
 
 describe('onChangeSearchWords', () => {
   const currentState: State = {
-    ...state,
+    ...baseState,
     search: {
-      ...state.search,
+      ...baseState.search,
       words: ['imano', 'kotoba'],
       page: 4,
     },
@@ -214,9 +214,9 @@ describe('onChangeShowAll', () => {
     '現在の全キャラ表示フラグが $currentShowAll で変更後のフラグが $newShowAll の場合',
     ({ currentShowAll, newShowAll }) => {
       const currentState: State = {
-        ...state,
+        ...baseState,
         search: {
-          ...state.search,
+          ...baseState.search,
           showAll: currentShowAll,
           page: 3,
         },
@@ -247,9 +247,9 @@ describe('onClickTag', () => {
 
   describe('今のstateがタグ検索のとき', () => {
     const currentState: State = {
-      ...state,
+      ...baseState,
       search: {
-        ...state.search,
+        ...baseState.search,
         target: SearchTarget.TAG,
         words: ['imano', 'tag'],
         page: 2,
@@ -282,9 +282,9 @@ describe('onClickTag', () => {
 
   describe('今のstateが名前検索のとき', () => {
     const currentState: State = {
-      ...state,
+      ...baseState,
       search: {
-        ...state.search,
+        ...baseState.search,
         target: SearchTarget.NAME,
         words: ['imano', 'name'],
         page: 2,
@@ -316,9 +316,9 @@ describe('onClickTag', () => {
 describe('onShowNextPage', () => {
   let nextState: State;
   const currentState = {
-    ...state,
+    ...baseState,
     search: {
-      ...state.search,
+      ...baseState.search,
       page: 1,
     },
   };

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -96,80 +96,35 @@ describe('onLoadCharacters', () => {
 describe('onChangeSearchTarget', () => {
   let nextState: State;
 
-  describe.each`
-    target
-    ${SearchTarget.TAG}
-    ${SearchTarget.NAME}
-  `('現在の検索対象と変更後の検索対象が一致する場合', ({ target }) => {
-    const currentState: State = {
-      ...baseState,
-      search: {
-        ...baseState.search,
-        target,
-        words: ['imano', 'tango'],
-        page: 5,
-      },
-    };
+  const currentState: State = {
+    ...baseState,
+    search: {
+      ...baseState.search,
+      target: SearchTarget.NAME,
+      words: ['imano', 'tango'],
+      page: 5,
+    },
+  };
 
-    beforeEach(() => {
-      nextState = onChangeSearchTarget(currentState, target);
-    });
-
-    it('検索対象が変更されていない', () => {
-      expect(nextState.search.target).toBe(target);
-    });
-
-    it('検索ワードが変更されていない', () => {
-      expect(nextState.search.words).toEqual(currentState.search.words);
-    });
-
-    it('ページがリセットされている', () => {
-      expect(nextState.search.page).toBe(1);
-    });
-
-    it('フィルタ関数が呼び出されている', () => {
-      expect(filterCharacters).toBeCalled();
-    });
+  beforeEach(() => {
+    nextState = onChangeSearchTarget(currentState, SearchTarget.TAG);
   });
 
-  describe.each`
-    currentTarget        | newTarget
-    ${SearchTarget.TAG}  | ${SearchTarget.NAME}
-    ${SearchTarget.NAME} | ${SearchTarget.TAG}
-  `(
-    '現在の検索対象と変更後の検索対象が一致しない場合',
-    ({ currentTarget, newTarget }) => {
-      const currentState: State = {
-        ...baseState,
-        search: {
-          ...baseState.search,
-          target: currentTarget,
-          words: ['imano', 'tango'],
-          page: 5,
-        },
-      };
+  it('検索対象が変更されている', () => {
+    expect(nextState.search.target).toBe(SearchTarget.TAG);
+  });
 
-      beforeEach(() => {
-        nextState = onChangeSearchTarget(currentState, newTarget);
-      });
+  it('検索ワードがリセットされている', () => {
+    expect(nextState.search.words).toEqual([]);
+  });
 
-      it('検索対象が変更されている', () => {
-        expect(nextState.search.target).toBe(newTarget);
-      });
+  it('ページがリセットされている', () => {
+    expect(nextState.search.page).toBe(1);
+  });
 
-      it('検索ワードがリセットされている', () => {
-        expect(nextState.search.words).toEqual([]);
-      });
-
-      it('ページがリセットされている', () => {
-        expect(nextState.search.page).toBe(1);
-      });
-
-      it('フィルタ関数が呼び出されている', () => {
-        expect(filterCharacters).toBeCalled();
-      });
-    }
-  );
+  it('フィルタ関数が呼び出されている', () => {
+    expect(filterCharacters).toBeCalled();
+  });
 });
 
 describe('onChangeSearchWords', () => {

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -19,6 +19,7 @@ export const onLoadCharactersData = (
     search: {
       ...search,
       results,
+      page: 1,
     },
   };
 };
@@ -38,6 +39,7 @@ export const onChangeSearchTarget = (
       target,
       words,
       results,
+      page: 1,
     },
   };
 };
@@ -52,6 +54,7 @@ export const onChangeSearchWords = (state: State, words: string[]): State => {
       ...search,
       words,
       results,
+      page: 1,
     },
   };
 };
@@ -66,6 +69,7 @@ export const onChangeShowAll = (state: State, showAll: boolean): State => {
       ...search,
       showAll,
       results,
+      page: 1,
     },
   };
 };
@@ -84,6 +88,18 @@ export const onClickTag = (state: State, label: string): State => {
       target,
       words,
       results,
+      page: 1,
+    },
+  };
+};
+
+export const onShowNextPage = (state: State): State => {
+  const { search } = state;
+  return {
+    ...state,
+    search: {
+      ...search,
+      page: search.page + 1,
     },
   };
 };

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -30,14 +30,13 @@ export const onChangeSearchTarget = (
 ): State => {
   const { characters, search } = state;
   const { showAll } = search;
-  const words = search.target === target ? search.words : [];
-  const results = filterCharacters(characters, target, words, showAll);
+  const results = filterCharacters(characters, target, [], showAll);
   return {
     ...state,
     search: {
       ...search,
       target,
-      words,
+      words: [],
       results,
       page: 1,
     },

--- a/src/flux/reducer.spec.ts
+++ b/src/flux/reducer.spec.ts
@@ -5,6 +5,7 @@ import {
   onChangeShowAll,
   onClickTag,
   onLoadCharactersData,
+  onShowNextPage,
 } from './dispatch';
 import { reducer } from './reducer';
 import { initialState } from './state';
@@ -21,6 +22,7 @@ describe('reducer', () => {
     ${'change-search-words'}  | ${onChangeSearchWords}
     ${'change-show-all'}      | ${onChangeShowAll}
     ${'click-tag'}            | ${onClickTag}
+    ${'show-next-page'}       | ${onShowNextPage}
   `('action.typeが$typeのとき', ({ type, method }) => {
     beforeEach(() => {
       reducer(state, { type } as unknown as Action);

--- a/src/flux/reducer.ts
+++ b/src/flux/reducer.ts
@@ -7,6 +7,7 @@ import {
   onChangeShowAll,
   onClickTag,
   onLoadCharactersData,
+  onShowNextPage,
 } from './dispatch';
 import { State } from './state';
 
@@ -22,6 +23,8 @@ export const reducer: Reducer<State, Action> = (state, action) => {
       return onChangeShowAll(state, action.showAll);
     case 'click-tag':
       return onClickTag(state, action.label);
+    case 'show-next-page':
+      return onShowNextPage(state);
     default:
       throw new Error('Invalid dispatch action');
   }

--- a/src/flux/state.ts
+++ b/src/flux/state.ts
@@ -7,6 +7,7 @@ interface SearchState {
   words: string[];
   showAll: boolean;
   results: TaggedCharacter[];
+  page: number;
 }
 
 export interface State {
@@ -27,5 +28,6 @@ export const initialState: State = {
     words: [],
     showAll: false,
     results: [],
+    page: 1,
   },
 };

--- a/src/test-utils/flux.tsx
+++ b/src/test-utils/flux.tsx
@@ -3,22 +3,21 @@ import React, { useReducer } from 'react';
 import { characters } from '../../sample/characters-data/sample.json';
 import { FluxContext } from '../flux/context';
 import { reducer } from '../flux/reducer';
-import { initialState, State } from '../flux/state';
+import { State } from '../flux/state';
 import { SearchTarget } from '../lib/search-target';
 
 export const initialTestState: State = {
-  ...initialState,
   isReady: true,
   characters,
   metadata: {
     character: 'テストキャラクター',
   },
   search: {
-    ...initialState.search,
     target: SearchTarget.TAG,
     words: ['あいうえお'],
     showAll: false,
     results: characters,
+    page: 2,
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3298,6 +3298,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/react-infinite-scroller@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-infinite-scroller/-/react-infinite-scroller-1.2.3.tgz#b8dcb0e5762c3f79cc92e574d2c77402524cab71"
+  integrity sha512-l60JckVoO+dxmKW2eEG7jbliEpITsTJvRPTe97GazjF5+ylagAuyYdXl8YY9DQsTP9QjhqGKZROknzgscGJy0A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-is@^16.7.1 || ^17.0.0":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
@@ -10399,7 +10406,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10632,6 +10639,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-infinite-scroller@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"
+  integrity sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-inspector@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
Resolve #84 
- `react-infinite-scroller` を導入して検索結果表示を無限スクロールに対応させる
    - https://github.com/danbovey/react-infinite-scroller
- ページ管理はfluxで行う
    - 検索結果が変わった場合ページリセットが必要だが、 `react-infinite-scroller` はそれに対応していないため
- おまけ: `onChangeSearchTarget` で今と同じ検索対象に変更されるケースを考慮しない
    - 今の所UI的にそういうケースが発生しないため